### PR TITLE
Fix parent domain override of subdomain cookie changes

### DIFF
--- a/src/lib/store/store.ts
+++ b/src/lib/store/store.ts
@@ -26,9 +26,9 @@ export class StoresGroup implements Store {
 
   public get<T>(key: string): T | null {
     return (
-      this.cookiesStore.get<T>(key) ||
-      this.localStore.get<T>(key) ||
-      this.memoryStore.get<T>(key) ||
+      this.cookiesStore.get<T>(key) ??
+      this.localStore.get<T>(key) ??
+      this.memoryStore.get<T>(key) ??
       null
     );
   }


### PR DESCRIPTION
# Description
When a subdomain sets a cookie on the parent domain, the parent domain overrides this change because it starts pulling data from localStorage first.