### PR TITLE
[PATCH] Add the plugin name to the event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@journifyio/js-sdk",
-  "version": "0.0.202",
+  "version": "0.0.203",
   "description": "Journify SDK in JavaScript",
   "main": "dist/lib/es5/index.js",
   "types": "dist/lib/es5/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@journifyio/js-sdk",
-  "version": "0.0.203",
+  "version": "0.0.202",
   "description": "Journify SDK in JavaScript",
   "main": "dist/lib/es5/index.js",
   "types": "dist/lib/es5/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@journifyio/js-sdk",
-  "version": "0.0.201",
+  "version": "0.0.202",
   "description": "Journify SDK in JavaScript",
   "main": "dist/lib/es5/index.js",
   "types": "dist/lib/es5/index.d.ts",

--- a/src/lib/generated/libVersion.ts
+++ b/src/lib/generated/libVersion.ts
@@ -1,2 +1,2 @@
 // This file is generated.
-export const LIB_VERSION = "0.0.201";
+export const LIB_VERSION = "0.0.202";

--- a/src/lib/generated/libVersion.ts
+++ b/src/lib/generated/libVersion.ts
@@ -1,2 +1,2 @@
 // This file is generated.
-export const LIB_VERSION = "0.0.202";
+export const LIB_VERSION = "0.0.203";

--- a/src/lib/generated/libVersion.ts
+++ b/src/lib/generated/libVersion.ts
@@ -1,2 +1,2 @@
 // This file is generated.
-export const LIB_VERSION = "0.0.203";
+export const LIB_VERSION = "0.0.202";

--- a/src/lib/transport/_tests/queue.test.ts
+++ b/src/lib/transport/_tests/queue.test.ts
@@ -32,7 +32,6 @@ describe("EventQueueImpl class", () => {
       pluginMock.name = "plugin1";
 
       const eventId = "event-queue-ctx-id-example-1";
-      const eventWithPlugin = `${eventId}/${pluginMock.name}`;
 
       const subscribeToDelivery = jest.spyOn(
         EventQueueImpl.prototype as any,
@@ -62,7 +61,8 @@ describe("EventQueueImpl class", () => {
       expect(successIdenitfy.identify).toHaveBeenCalledTimes(1);
       expect(successIdenitfy.identify).toBeCalledWith({
         ...eventCtx,
-        id: eventWithPlugin,
+        id: `${eventId}/${pluginMock.name}`,
+        pluginName: pluginMock.name,
       });
     });
 
@@ -90,8 +90,6 @@ describe("EventQueueImpl class", () => {
       );
 
       const eventId = "event-queue-ctx-id-example-1";
-      const eventWithPlugin1 = `${eventId}/${plugin1.name}`;
-      const eventWithPlugin2 = `${eventId}/${plugin2.name}`;
 
       const eventCtx = new ContextMock(eventId, {
         type: JournifyEventType.TRACK,
@@ -103,11 +101,13 @@ describe("EventQueueImpl class", () => {
       expect(trackFunc.track).toBeCalledTimes(2);
       expect(trackFunc.track).nthCalledWith(1, {
         ...eventCtx,
-        id: eventWithPlugin1,
+        id: `${eventId}/${plugin1.name}`,
+        pluginName: plugin1.name,
       });
       expect(trackFunc.track).nthCalledWith(2, {
         ...eventCtx,
-        id: eventWithPlugin2,
+        id: `${eventId}/${plugin2.name}`,
+        pluginName: plugin2.name,
       });
     });
 
@@ -144,8 +144,6 @@ describe("EventQueueImpl class", () => {
       );
 
       const eventId = "event-queue-ctx-id-example-1";
-      const eventWithPlugin1 = `${eventId}/${plugin1.name}`;
-      const eventWithPlugin2 = `${eventId}/${plugin2.name}`;
 
       const eventCtx = new ContextMock(eventId, {
         type: JournifyEventType.TRACK,
@@ -157,12 +155,14 @@ describe("EventQueueImpl class", () => {
       expect(successtrackFunc.track).toHaveBeenCalledTimes(1);
       expect(successtrackFunc.track).toHaveBeenCalledWith({
         ...eventCtx,
-        id: eventWithPlugin1,
+        id: `${eventId}/${plugin1.name}`,
+        pluginName: plugin1.name,
       });
       expect(failuretrackFunc.track).toHaveBeenCalledTimes(2);
       expect(failuretrackFunc.track).toHaveBeenCalledWith(
         expect.objectContaining({
-          id: eventWithPlugin2,
+          id: `${eventId}/${plugin2.name}`,
+          pluginName: plugin2.name,
         })
       );
     });
@@ -262,6 +262,7 @@ describe("EventQueueImpl class", () => {
       expect(subscribeToDelivery).toBeCalledTimes(1);
       expect(emit).nthCalledWith(1, ON_OPERATION_DELAY_FINISH);
     });
+
     it("Should process same event if all plugins failed", async () => {
       const trackFunc: JPluginMockFuncs = {
         track: jest.fn((ctxParam: Context) => Promise.reject(ctxParam)),

--- a/src/lib/transport/context.ts
+++ b/src/lib/transport/context.ts
@@ -4,29 +4,32 @@ import { WithId } from "../lib/priorityQueue";
 
 export interface Context extends WithId {
   getEvent(): JournifyEvent;
+  getPluginId(): string;
   isSame(other: Context): boolean;
   setFailedDelivery(failedDelivery: ContextFailedDelivery): void;
   getFailedDelivery(): ContextFailedDelivery | null;
 }
 
 export interface ContextFactory {
-  newContext(event: JournifyEvent, id?: string): Context;
+  newContext(event: JournifyEvent, id?: string, pluginID?: string): Context;
 }
 
 export class ContextFactoryImpl implements ContextFactory {
-  newContext(event: JournifyEvent, id?: string): Context {
-    return new ContextImpl(event, id);
+  newContext(event: JournifyEvent, id?: string, pluginId?: string): Context {
+    return new ContextImpl(event, id, pluginId);
   }
 }
 
 class ContextImpl implements Context {
   private readonly event: JournifyEvent;
   private readonly id: string;
+  private readonly pluginId: string;
   private failedDelivery?: ContextFailedDelivery;
 
-  public constructor(event: JournifyEvent, id?: string) {
+  public constructor(event: JournifyEvent, id?: string, pluginId?: string) {
     this.event = event;
     this.id = id ?? uuid();
+    this.pluginId = pluginId;
   }
 
   public getEvent(): JournifyEvent {
@@ -35,6 +38,10 @@ class ContextImpl implements Context {
 
   public getId(): string {
     return this.id;
+  }
+
+  public getPluginId(): string {
+    return this.pluginId;
   }
 
   public isSame(other: Context): boolean {

--- a/src/lib/transport/context.ts
+++ b/src/lib/transport/context.ts
@@ -4,32 +4,32 @@ import { WithId } from "../lib/priorityQueue";
 
 export interface Context extends WithId {
   getEvent(): JournifyEvent;
-  getPluginId(): string;
+  getPluginName(): string;
   isSame(other: Context): boolean;
   setFailedDelivery(failedDelivery: ContextFailedDelivery): void;
   getFailedDelivery(): ContextFailedDelivery | null;
 }
 
 export interface ContextFactory {
-  newContext(event: JournifyEvent, id?: string, pluginID?: string): Context;
+  newContext(event: JournifyEvent, id?: string, pluginName?: string): Context;
 }
 
 export class ContextFactoryImpl implements ContextFactory {
-  newContext(event: JournifyEvent, id?: string, pluginId?: string): Context {
-    return new ContextImpl(event, id, pluginId);
+  newContext(event: JournifyEvent, id?: string, pluginName?: string): Context {
+    return new ContextImpl(event, id, pluginName);
   }
 }
 
 class ContextImpl implements Context {
   private readonly event: JournifyEvent;
   private readonly id: string;
-  private readonly pluginId: string;
+  private readonly pluginName: string;
   private failedDelivery?: ContextFailedDelivery;
 
-  public constructor(event: JournifyEvent, id?: string, pluginId?: string) {
+  public constructor(event: JournifyEvent, id?: string, pluginName?: string) {
     this.event = event;
     this.id = id ?? uuid();
-    this.pluginId = pluginId;
+    this.pluginName = pluginName;
   }
 
   public getEvent(): JournifyEvent {
@@ -40,8 +40,8 @@ class ContextImpl implements Context {
     return this.id;
   }
 
-  public getPluginId(): string {
-    return this.pluginId;
+  public getPluginName(): string {
+    return this.pluginName;
   }
 
   public isSame(other: Context): boolean {

--- a/src/lib/transport/queue.ts
+++ b/src/lib/transport/queue.ts
@@ -117,7 +117,7 @@ export class EventQueueImpl extends EmitterImpl implements EventQueue {
             attempts.push(this.attempt(p, ctxToDeliver))
           }
 
-          Promise.all(attempts).then(() => resolve).catch(reject);
+          Promise.all(attempts).then(() => resolve()).catch(reject);
       }, 0);
     });
   }

--- a/src/lib/transport/queue.ts
+++ b/src/lib/transport/queue.ts
@@ -47,9 +47,7 @@ export class EventQueueImpl extends EmitterImpl implements EventQueue {
 
   private push(ctx: Context): Context[] {
     const updatedContextEvents = this.plugins.map((p) => {
-      const newId = generateNewIDWithPlugin(ctx.getId(), p.name);
-      const newCtx = this.contextFactory.newContext(ctx.getEvent(), newId);
-      return newCtx;
+      return this.contextFactory.newContext(ctx.getEvent(), ctx.getId(), p.name);
     });
     this.pQueue.push(...updatedContextEvents);
     return updatedContextEvents;
@@ -149,8 +147,4 @@ export class EventQueueImpl extends EmitterImpl implements EventQueue {
       this.emit(FLUSH_EVENT_NAME, ctxToDeliver, false);
     }
   }
-}
-
-function generateNewIDWithPlugin(id: string, plugin: string): string {
-  return `${id}/${plugin}`;
 }

--- a/src/lib/transport/queue.ts
+++ b/src/lib/transport/queue.ts
@@ -115,7 +115,6 @@ export class EventQueueImpl extends EmitterImpl implements EventQueue {
           const attempts: Promise<void>[] = [];
           for (const p of eventPlugins) {
             attempts.push(this.attempt(p, ctxToDeliver))
-
           }
 
           Promise.all(attempts).then(() => resolve).catch(reject);

--- a/src/lib/transport/queue.ts
+++ b/src/lib/transport/queue.ts
@@ -111,6 +111,7 @@ export class EventQueueImpl extends EmitterImpl implements EventQueue {
               resolve();
               return;
           }
+
           for (const p of eventPlugins) {
               this.attempt(p, ctxToDeliver).then(resolve).catch(reject);
           }

--- a/src/lib/transport/queue.ts
+++ b/src/lib/transport/queue.ts
@@ -93,7 +93,7 @@ export class EventQueueImpl extends EmitterImpl implements EventQueue {
       return;
     }
 
-    await new Promise((resolve, reject) => {
+    await new Promise<void>((resolve, reject) => {
       setTimeout(() => {
           const eventPlugins = this.plugins.filter((p) =>
               ctxToDeliver.getPluginName() == p.name
@@ -108,6 +108,7 @@ export class EventQueueImpl extends EmitterImpl implements EventQueue {
                       },
                   }
               );
+              resolve();
               return;
           }
           for (const p of eventPlugins) {

--- a/src/lib/transport/queue.ts
+++ b/src/lib/transport/queue.ts
@@ -112,9 +112,13 @@ export class EventQueueImpl extends EmitterImpl implements EventQueue {
               return;
           }
 
+          const attempts: Promise<void>[] = [];
           for (const p of eventPlugins) {
-              this.attempt(p, ctxToDeliver).then(resolve).catch(reject);
+            attempts.push(this.attempt(p, ctxToDeliver))
+
           }
+
+          Promise.all(attempts).then(() => resolve).catch(reject);
       }, 0);
     });
   }

--- a/src/test/mocks/context.ts
+++ b/src/test/mocks/context.ts
@@ -7,15 +7,18 @@ import {
 
 export class ContextMock implements Context {
   private readonly id: string;
+  private readonly pluginName: string;
   private readonly event: JournifyEvent;
   private failedDelivery: ContextFailedDelivery;
 
   constructor(
     id: string,
     event: JournifyEvent,
+    pluginName?: string,
     failedDelivery?: ContextFailedDelivery
   ) {
     this.id = id;
+    this.pluginName = pluginName;
     this.event = event;
     this.failedDelivery = failedDelivery;
   }
@@ -30,6 +33,10 @@ export class ContextMock implements Context {
 
   getId(): string {
     return this.id;
+  }
+
+  getPluginName(): string {
+    return this.pluginName;
   }
 
   isSame(other: Context): boolean {


### PR DESCRIPTION
# Description
This is a PR to adds the plugin name to the event name to make the filtering process more readable and resilient