### PR TITLE
feat: persist traits when track and page are called

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,5 +65,9 @@
     "typescript": "^4.7.4",
     "webpack": "5.94.0",
     "webpack-cli": "^5.1.4"
+  },
+  "prettier": {
+    "useTabs": false,
+    "tabWidth": 2
   }
 }

--- a/src/lib/api/sdk.ts
+++ b/src/lib/api/sdk.ts
@@ -68,6 +68,8 @@ export class Sdk extends EmitterImpl {
       throw new Error("Event name is missing");
     }
 
+    await this.user.setTraits(traits as Traits);
+
     const event = await this.eventFactory.newTrackEvent(
       eventName,
       properties as JournifyEvent["properties"],
@@ -95,6 +97,8 @@ export class Sdk extends EmitterImpl {
     if (isNonValidString(pageName)) {
       pageName = document.title;
     }
+
+    await this.user.setTraits(traits as Traits);
 
     const event = await this.eventFactory.newPageEvent(
       pageName,


### PR DESCRIPTION
# Description
When `track` and `page` methods are called. the passed traits will be persisted in cookies.

# Github Issue(s)
Closes [PRO-667](https://linear.app/journify-infra/issue/PRO-667/update-journify-javascript-sdk-to-update-the-user-traits-when-the)
---
***When reviewing this PR, please adhere to [conventional comments](https://conventionalcomments.org).***
