### PR TITLE
[PATCH] feat: implement type coercion in event filter matching

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@journifyio/js-sdk",
-  "version": "0.0.204",
+  "version": "0.0.205",
   "description": "Journify SDK in JavaScript",
   "main": "dist/lib/es5/index.js",
   "types": "dist/lib/es5/index.d.ts",

--- a/src/lib/generated/libVersion.ts
+++ b/src/lib/generated/libVersion.ts
@@ -1,2 +1,2 @@
 // This file is generated.
-export const LIB_VERSION = "0.0.204";
+export const LIB_VERSION = "0.0.205";

--- a/src/lib/lib/utils.ts
+++ b/src/lib/lib/utils.ts
@@ -7,7 +7,7 @@ export const parseNumberToString = (value: number | string): string => {
 
 export function normalizePhone(
   phoneNumber: string,
-  countryCode: string
+  countryCode: string,
 ): string {
   // handle empty and sha256 values
   if (!phoneNumber || phoneNumber?.length == 64) {
@@ -68,4 +68,21 @@ export function cleanTraits(obj: unknown): Record<string, unknown> {
   }
 
   return cleanedObj;
+}
+
+// Coerces a string value to the type of the target value (number, boolean, or string)
+export function coerceToType(value: string, target: unknown): unknown {
+  if (target === null || target === undefined) {
+    return value;
+  }
+  switch (typeof target) {
+    case "number": {
+      const num = Number(value);
+      return isNaN(num) ? value : num;
+    }
+    case "boolean":
+      return value === "true" ? true : value === "false" ? false : value;
+    default:
+      return value;
+  }
 }

--- a/src/lib/transport/plugins/lib/_tests/eventMapping.test.ts
+++ b/src/lib/transport/plugins/lib/_tests/eventMapping.test.ts
@@ -1,5 +1,5 @@
 import {EventFilter, EventMapping, FilterOperator, TrackingEventType} from "../../plugin";
-import {JournifyEventType} from "../../../../domain/event";
+import {JournifyEvent, JournifyEventType} from "../../../../domain/event";
 import {Context} from "../../../context";
 import {EventMapperFactoryImpl} from "../eventMapping";
 
@@ -234,6 +234,473 @@ describe("EventMapper", () => {
             });
 
             expect(mappedEvent).toBeNull()
+        });
+
+        describe("matchFilter - type coercion", () => {
+            function makeMapper(filter: EventFilter) {
+                return eventMapperFactory.newEventMapper([
+                    {
+                        enabled: true,
+                        event_type: TrackingEventType.TRACK_EVENT,
+                        event_name: "test",
+                        destination_event_key: "DEST",
+                        filters: [filter],
+                    },
+                ]);
+            }
+
+            function trackEvent(properties: Record<string, unknown>) {
+                return {
+                    type: JournifyEventType.TRACK,
+                    event: "test",
+                    properties,
+                } as JournifyEvent;
+            }
+
+            // --- EQUALS with type coercion ---
+            it("EQUALS: string filter matches string event value", () => {
+                const mapper = makeMapper({
+                    field: "properties.name",
+                    operator: FilterOperator.EQUALS,
+                    value: "hello",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ name: "hello" }))).toEqual({ pixelEventName: "DEST" });
+            });
+
+            it("EQUALS: string filter does not match different string", () => {
+                const mapper = makeMapper({
+                    field: "properties.name",
+                    operator: FilterOperator.EQUALS,
+                    value: "hello",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ name: "world" }))).toBeNull();
+            });
+
+            it("EQUALS: string filter '42' matches number 42 via coercion", () => {
+                const mapper = makeMapper({
+                    field: "properties.count",
+                    operator: FilterOperator.EQUALS,
+                    value: "42",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ count: 42 }))).toEqual({ pixelEventName: "DEST" });
+            });
+
+            it("EQUALS: string filter '42' does not match number 99", () => {
+                const mapper = makeMapper({
+                    field: "properties.count",
+                    operator: FilterOperator.EQUALS,
+                    value: "42",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ count: 99 }))).toBeNull();
+            });
+
+            it("EQUALS: string filter 'true' matches boolean true via coercion", () => {
+                const mapper = makeMapper({
+                    field: "properties.active",
+                    operator: FilterOperator.EQUALS,
+                    value: "true",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ active: true }))).toEqual({ pixelEventName: "DEST" });
+            });
+
+            it("EQUALS: string filter 'false' matches boolean false via coercion", () => {
+                const mapper = makeMapper({
+                    field: "properties.active",
+                    operator: FilterOperator.EQUALS,
+                    value: "false",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ active: false }))).toEqual({ pixelEventName: "DEST" });
+            });
+
+            it("EQUALS: string filter 'true' does not match boolean false", () => {
+                const mapper = makeMapper({
+                    field: "properties.active",
+                    operator: FilterOperator.EQUALS,
+                    value: "true",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ active: false }))).toBeNull();
+            });
+
+            it("EQUALS: string filter '3.14' matches number 3.14", () => {
+                const mapper = makeMapper({
+                    field: "properties.rate",
+                    operator: FilterOperator.EQUALS,
+                    value: "3.14",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ rate: 3.14 }))).toEqual({ pixelEventName: "DEST" });
+            });
+
+            it("EQUALS: non-numeric string filter stays string when event value is number", () => {
+                const mapper = makeMapper({
+                    field: "properties.count",
+                    operator: FilterOperator.EQUALS,
+                    value: "abc",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ count: 42 }))).toBeNull();
+            });
+
+            // --- NOT_EQUALS with type coercion ---
+            it("NOT_EQUALS: string filter '42' does not match number 42 (equal after coercion)", () => {
+                const mapper = makeMapper({
+                    field: "properties.count",
+                    operator: FilterOperator.NOT_EQUALS,
+                    value: "42",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ count: 42 }))).toBeNull();
+            });
+
+            it("NOT_EQUALS: string filter '42' matches number 99 (different after coercion)", () => {
+                const mapper = makeMapper({
+                    field: "properties.count",
+                    operator: FilterOperator.NOT_EQUALS,
+                    value: "42",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ count: 99 }))).toEqual({ pixelEventName: "DEST" });
+            });
+
+            it("NOT_EQUALS: string filter 'true' does not match boolean true", () => {
+                const mapper = makeMapper({
+                    field: "properties.active",
+                    operator: FilterOperator.NOT_EQUALS,
+                    value: "true",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ active: true }))).toBeNull();
+            });
+
+            it("NOT_EQUALS: string filter 'true' matches boolean false", () => {
+                const mapper = makeMapper({
+                    field: "properties.active",
+                    operator: FilterOperator.NOT_EQUALS,
+                    value: "true",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ active: false }))).toEqual({ pixelEventName: "DEST" });
+            });
+
+            // --- GREATER_THAN with type coercion ---
+            it("GREATER_THAN: number event value > string filter coerced to number", () => {
+                const mapper = makeMapper({
+                    field: "properties.amount",
+                    operator: FilterOperator.GREATER_THAN,
+                    value: "100",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ amount: 200 }))).toEqual({ pixelEventName: "DEST" });
+            });
+
+            it("GREATER_THAN: number event value not > string filter coerced to number", () => {
+                const mapper = makeMapper({
+                    field: "properties.amount",
+                    operator: FilterOperator.GREATER_THAN,
+                    value: "100",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ amount: 50 }))).toBeNull();
+            });
+
+            it("GREATER_THAN: equal values should not match", () => {
+                const mapper = makeMapper({
+                    field: "properties.amount",
+                    operator: FilterOperator.GREATER_THAN,
+                    value: "100",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ amount: 100 }))).toBeNull();
+            });
+
+            // --- GREATER_THAN_OR_EQ with type coercion ---
+            it("GREATER_THAN_OR_EQ: equal values should match", () => {
+                const mapper = makeMapper({
+                    field: "properties.amount",
+                    operator: FilterOperator.GREATER_THAN_OR_EQ,
+                    value: "100",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ amount: 100 }))).toEqual({ pixelEventName: "DEST" });
+            });
+
+            it("GREATER_THAN_OR_EQ: greater value should match", () => {
+                const mapper = makeMapper({
+                    field: "properties.amount",
+                    operator: FilterOperator.GREATER_THAN_OR_EQ,
+                    value: "100",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ amount: 101 }))).toEqual({ pixelEventName: "DEST" });
+            });
+
+            it("GREATER_THAN_OR_EQ: lesser value should not match", () => {
+                const mapper = makeMapper({
+                    field: "properties.amount",
+                    operator: FilterOperator.GREATER_THAN_OR_EQ,
+                    value: "100",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ amount: 99 }))).toBeNull();
+            });
+
+            // --- LESS_THAN with type coercion ---
+            it("LESS_THAN: number event value < string filter coerced to number", () => {
+                const mapper = makeMapper({
+                    field: "properties.amount",
+                    operator: FilterOperator.LESS_THAN,
+                    value: "100",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ amount: 50 }))).toEqual({ pixelEventName: "DEST" });
+            });
+
+            it("LESS_THAN: equal values should not match", () => {
+                const mapper = makeMapper({
+                    field: "properties.amount",
+                    operator: FilterOperator.LESS_THAN,
+                    value: "100",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ amount: 100 }))).toBeNull();
+            });
+
+            it("LESS_THAN: greater value should not match", () => {
+                const mapper = makeMapper({
+                    field: "properties.amount",
+                    operator: FilterOperator.LESS_THAN,
+                    value: "100",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ amount: 200 }))).toBeNull();
+            });
+
+            // --- LESS_THAN_OR_EQ with type coercion ---
+            it("LESS_THAN_OR_EQ: equal values should match", () => {
+                const mapper = makeMapper({
+                    field: "properties.amount",
+                    operator: FilterOperator.LESS_THAN_OR_EQ,
+                    value: "100",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ amount: 100 }))).toEqual({ pixelEventName: "DEST" });
+            });
+
+            it("LESS_THAN_OR_EQ: lesser value should match", () => {
+                const mapper = makeMapper({
+                    field: "properties.amount",
+                    operator: FilterOperator.LESS_THAN_OR_EQ,
+                    value: "100",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ amount: 50 }))).toEqual({ pixelEventName: "DEST" });
+            });
+
+            it("LESS_THAN_OR_EQ: greater value should not match", () => {
+                const mapper = makeMapper({
+                    field: "properties.amount",
+                    operator: FilterOperator.LESS_THAN_OR_EQ,
+                    value: "100",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ amount: 200 }))).toBeNull();
+            });
+
+            // --- LESS_THAN_OR_EQ with float coercion ---
+            it("LESS_THAN_OR_EQ: float string filter coerced correctly", () => {
+                const mapper = makeMapper({
+                    field: "properties.price",
+                    operator: FilterOperator.LESS_THAN_OR_EQ,
+                    value: "9.99",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ price: 9.99 }))).toEqual({ pixelEventName: "DEST" });
+                expect(mapper.applyEventMapping(trackEvent({ price: 10 }))).toBeNull();
+            });
+        });
+
+        describe("matchFilter - string operators", () => {
+            function makeMapper(filter: EventFilter) {
+                return eventMapperFactory.newEventMapper([
+                    {
+                        enabled: true,
+                        event_type: TrackingEventType.TRACK_EVENT,
+                        event_name: "test",
+                        destination_event_key: "DEST",
+                        filters: [filter],
+                    },
+                ]);
+            }
+
+            function trackEvent(properties: Record<string, unknown>) {
+                return {
+                    type: JournifyEventType.TRACK,
+                    event: "test",
+                    properties,
+                } as JournifyEvent;
+            }
+
+            // --- CONTAINS ---
+            it("CONTAINS: matches when event value contains filter value", () => {
+                const mapper = makeMapper({
+                    field: "properties.name",
+                    operator: FilterOperator.CONTAINS,
+                    value: "world",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ name: "hello world" }))).toEqual({ pixelEventName: "DEST" });
+            });
+
+            it("CONTAINS: does not match when event value does not contain filter value", () => {
+                const mapper = makeMapper({
+                    field: "properties.name",
+                    operator: FilterOperator.CONTAINS,
+                    value: "xyz",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ name: "hello world" }))).toBeNull();
+            });
+
+            // --- NOT_CONTAINS ---
+            it("NOT_CONTAINS: matches when event value does not contain filter value", () => {
+                const mapper = makeMapper({
+                    field: "properties.name",
+                    operator: FilterOperator.NOT_CONTAINS,
+                    value: "xyz",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ name: "hello world" }))).toEqual({ pixelEventName: "DEST" });
+            });
+
+            it("NOT_CONTAINS: does not match when event value contains filter value", () => {
+                const mapper = makeMapper({
+                    field: "properties.name",
+                    operator: FilterOperator.NOT_CONTAINS,
+                    value: "hello",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ name: "hello world" }))).toBeNull();
+            });
+
+            // --- STARTS_WITH ---
+            it("STARTS_WITH: matches when event value starts with filter value", () => {
+                const mapper = makeMapper({
+                    field: "properties.url",
+                    operator: FilterOperator.STARTS_WITH,
+                    value: "https://",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ url: "https://example.com" }))).toEqual({ pixelEventName: "DEST" });
+            });
+
+            it("STARTS_WITH: does not match when event value does not start with filter value", () => {
+                const mapper = makeMapper({
+                    field: "properties.url",
+                    operator: FilterOperator.STARTS_WITH,
+                    value: "https://",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ url: "http://example.com" }))).toBeNull();
+            });
+
+            // --- ENDS_WITH ---
+            it("ENDS_WITH: matches when event value ends with filter value", () => {
+                const mapper = makeMapper({
+                    field: "properties.email",
+                    operator: FilterOperator.ENDS_WITH,
+                    value: "@example.com",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ email: "user@example.com" }))).toEqual({ pixelEventName: "DEST" });
+            });
+
+            it("ENDS_WITH: does not match when event value does not end with filter value", () => {
+                const mapper = makeMapper({
+                    field: "properties.email",
+                    operator: FilterOperator.ENDS_WITH,
+                    value: "@example.com",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ email: "user@other.com" }))).toBeNull();
+            });
+        });
+
+        describe("matchFilter - edge cases", () => {
+            function makeMapper(filter: EventFilter) {
+                return eventMapperFactory.newEventMapper([
+                    {
+                        enabled: true,
+                        event_type: TrackingEventType.TRACK_EVENT,
+                        event_name: "test",
+                        destination_event_key: "DEST",
+                        filters: [filter],
+                    },
+                ]);
+            }
+
+            function trackEvent(properties: Record<string, unknown>) {
+                return {
+                    type: JournifyEventType.TRACK,
+                    event: "test",
+                    properties,
+                } as JournifyEvent;
+            }
+
+            it("EQUALS: undefined event value does not match", () => {
+                const mapper = makeMapper({
+                    field: "properties.missing",
+                    operator: FilterOperator.EQUALS,
+                    value: "something",
+                });
+                expect(mapper.applyEventMapping(trackEvent({}))).toBeNull();
+            });
+
+            it("NOT_EQUALS: undefined event value does match (undefined !== 'something')", () => {
+                const mapper = makeMapper({
+                    field: "properties.missing",
+                    operator: FilterOperator.NOT_EQUALS,
+                    value: "something",
+                });
+                expect(mapper.applyEventMapping(trackEvent({}))).toEqual({ pixelEventName: "DEST" });
+            });
+
+            it("EQUALS: nested field access works", () => {
+                const mapper = makeMapper({
+                    field: "properties.nested.deep.value",
+                    operator: FilterOperator.EQUALS,
+                    value: "found",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ nested: { deep: { value: "found" } } }))).toEqual({ pixelEventName: "DEST" });
+            });
+
+            it("EQUALS: nested field access returns null for missing nested path", () => {
+                const mapper = makeMapper({
+                    field: "properties.nested.deep.value",
+                    operator: FilterOperator.EQUALS,
+                    value: "found",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ nested: {} }))).toBeNull();
+            });
+
+            it("EQUALS: number 0 matches string filter '0'", () => {
+                const mapper = makeMapper({
+                    field: "properties.count",
+                    operator: FilterOperator.EQUALS,
+                    value: "0",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ count: 0 }))).toEqual({ pixelEventName: "DEST" });
+            });
+
+            it("EQUALS: negative number matches string filter", () => {
+                const mapper = makeMapper({
+                    field: "properties.temp",
+                    operator: FilterOperator.EQUALS,
+                    value: "-5",
+                });
+                expect(mapper.applyEventMapping(trackEvent({ temp: -5 }))).toEqual({ pixelEventName: "DEST" });
+            });
+
+            it("multiple filters act as AND - all must match", () => {
+                const mapper = eventMapperFactory.newEventMapper([
+                    {
+                        enabled: true,
+                        event_type: TrackingEventType.TRACK_EVENT,
+                        event_name: "test",
+                        destination_event_key: "DEST",
+                        filters: [
+                            {
+                                field: "properties.active",
+                                operator: FilterOperator.EQUALS,
+                                value: "true",
+                            },
+                            {
+                                field: "properties.count",
+                                operator: FilterOperator.GREATER_THAN,
+                                value: "10",
+                            },
+                        ],
+                    },
+                ]);
+                // both match
+                expect(mapper.applyEventMapping(trackEvent({ active: true, count: 20 }))).toEqual({ pixelEventName: "DEST" });
+                // first matches, second doesn't
+                expect(mapper.applyEventMapping(trackEvent({ active: true, count: 5 }))).toBeNull();
+                // first doesn't match
+                expect(mapper.applyEventMapping(trackEvent({ active: false, count: 20 }))).toBeNull();
+            });
         });
 
         it("should return the event that matches filters when the same source event is mapped to different destination events", () => {

--- a/src/lib/transport/plugins/lib/eventMapping.ts
+++ b/src/lib/transport/plugins/lib/eventMapping.ts
@@ -123,18 +123,35 @@ function matchFilters(event: object, filters: EventFilter[]): boolean {
     return true;
 }
 
+function coerceToType(value: string, target: unknown): unknown {
+    if (target === null || target === undefined) {
+        return value;
+    }
+    switch (typeof target) {
+        case 'number': {
+            const num = Number(value);
+            return isNaN(num) ? value : num;
+        }
+        case 'boolean':
+            return value === 'true' ? true : value === 'false' ? false : value;
+        default:
+            return value;
+    }
+}
+
 function matchFilter(event: object, filter: EventFilter): boolean {
     const eventValue = getValue(event, filter.field);
+    const coercedFilterValue = coerceToType(filter.value, eventValue);
     switch (filter.operator) {
         case FilterOperator.EQUALS:
-            if (filter.value === eventValue) {
+            if (coercedFilterValue === eventValue) {
                 return true;
             }
 
             return filter.value?.includes(eventValue);
 
         case FilterOperator.NOT_EQUALS:
-            return filter.value !== eventValue;
+            return coercedFilterValue !== eventValue;
 
         case FilterOperator.CONTAINS:
             return eventValue?.includes(filter.value);
@@ -149,16 +166,16 @@ function matchFilter(event: object, filter: EventFilter): boolean {
             return eventValue?.endsWith(filter.value);
 
         case FilterOperator.GREATER_THAN:
-            return eventValue > filter.value;
+            return eventValue > coercedFilterValue;
 
         case FilterOperator.GREATER_THAN_OR_EQ:
-            return eventValue >= filter.value;
+            return eventValue >= coercedFilterValue;
 
         case FilterOperator.LESS_THAN:
-            return eventValue < filter.value;
+            return eventValue < coercedFilterValue;
 
         case FilterOperator.LESS_THAN_OR_EQ:
-            return eventValue <= filter.value;
+            return eventValue <= coercedFilterValue;
     }
 
     return false;

--- a/src/lib/transport/plugins/lib/eventMapping.ts
+++ b/src/lib/transport/plugins/lib/eventMapping.ts
@@ -1,182 +1,183 @@
-import {EventFilter, EventMapping, FilterOperator, PixelEventMapping, TrackingEventType} from "../plugin";
-import {JournifyDefaultEvent, JournifyEvent, JournifyEventType, MappedEvent} from "../../../domain/event";
-import {getValue} from "./value";
+import {
+  EventFilter,
+  EventMapping,
+  FilterOperator,
+  PixelEventMapping,
+  TrackingEventType,
+} from "../plugin";
+import {
+  JournifyDefaultEvent,
+  JournifyEvent,
+  JournifyEventType,
+  MappedEvent,
+} from "../../../domain/event";
+import { getValue } from "./value";
+import { coerceToType } from "../../../lib/utils";
 
 export interface EventMapperFactory {
-    newEventMapper(eventMappings: EventMapping[]): EventMapper;
+  newEventMapper(eventMappings: EventMapping[]): EventMapper;
 }
 
 export interface EventMapper {
-    applyEventMapping(event: JournifyEvent): MappedEvent | null;
+  applyEventMapping(event: JournifyEvent): MappedEvent | null;
 }
 
 export class EventMapperFactoryImpl implements EventMapperFactory {
-    public newEventMapper(eventMappings: EventMapping[]): EventMapper {
-        return new EventMapperImpl(eventMappings);
-    }
+  public newEventMapper(eventMappings: EventMapping[]): EventMapper {
+    return new EventMapperImpl(eventMappings);
+  }
 }
 
 export class EventMapperImpl implements EventMapper {
-    private readonly eventMappings: EventMapping[];
-    private readonly pageEventsMapping: Record<string, PixelEventMapping[]> = {};
-    private readonly trackEventsMapping: Record<string, PixelEventMapping[]> = {};
-    private readonly groupEventsMapping: Record<string, PixelEventMapping[]> = {};
-    private readonly identifyEventsMapping: Record<string, PixelEventMapping[]> =
-        {};
+  private readonly eventMappings: EventMapping[];
+  private readonly pageEventsMapping: Record<string, PixelEventMapping[]> = {};
+  private readonly trackEventsMapping: Record<string, PixelEventMapping[]> = {};
+  private readonly groupEventsMapping: Record<string, PixelEventMapping[]> = {};
+  private readonly identifyEventsMapping: Record<string, PixelEventMapping[]> =
+    {};
 
-    constructor(eventMappings: EventMapping[]) {
-        this.eventMappings = eventMappings;
-        this.init();
-    }
+  constructor(eventMappings: EventMapping[]) {
+    this.eventMappings = eventMappings;
+    this.init();
+  }
 
-    public applyEventMapping(event: JournifyEvent): MappedEvent | null {
-        let eventMappings: PixelEventMapping[];
-        switch (event.type) {
-            case JournifyEventType.TRACK:
-                eventMappings = this.trackEventsMapping[event.event];
-                break;
-            case JournifyEventType.PAGE:
-                eventMappings = this.pageEventsMapping[event.event || JournifyDefaultEvent.PAGE];
-                break;
-            case JournifyEventType.GROUP:
-                eventMappings = this.groupEventsMapping[
-                event.event || JournifyDefaultEvent.GROUP
-                    ];
-                break;
-            case JournifyEventType.IDENTIFY:
-                eventMappings = this.identifyEventsMapping[
-                event.event || JournifyDefaultEvent.IDENTIFY
-                    ];
-                break;
-            default:
-                return null;
-        }
-
-        if (!eventMappings || eventMappings.length === 0) {
-            return null;
-        }
-
-        for (const mapping of eventMappings) {
-            if (matchFilters(event, mapping.filters)) {
-                return {
-                    pixelEventName: mapping.pixelEventName,
-                };
-            }
-        }
-
+  public applyEventMapping(event: JournifyEvent): MappedEvent | null {
+    let eventMappings: PixelEventMapping[];
+    switch (event.type) {
+      case JournifyEventType.TRACK:
+        eventMappings = this.trackEventsMapping[event.event];
+        break;
+      case JournifyEventType.PAGE:
+        eventMappings =
+          this.pageEventsMapping[event.event || JournifyDefaultEvent.PAGE];
+        break;
+      case JournifyEventType.GROUP:
+        eventMappings =
+          this.groupEventsMapping[event.event || JournifyDefaultEvent.GROUP];
+        break;
+      case JournifyEventType.IDENTIFY:
+        eventMappings =
+          this.identifyEventsMapping[
+            event.event || JournifyDefaultEvent.IDENTIFY
+          ];
+        break;
+      default:
         return null;
     }
 
-    private init(): void {
-        for (const mapping of this.eventMappings) {
-            if (!mapping.enabled) {
-                continue;
-            }
-
-            const pixelMapping: PixelEventMapping = {
-                pixelEventName: mapping.destination_event_key,
-                filters: mapping.filters,
-            };
-
-            switch (mapping.event_type) {
-                case TrackingEventType.TRACK_EVENT:
-                    if (!this.trackEventsMapping[mapping.event_name]){
-                        this.trackEventsMapping[mapping.event_name] = [];
-                    }
-                    this.trackEventsMapping[mapping.event_name].push(pixelMapping);
-                    break;
-
-                case TrackingEventType.PAGE_EVENT:
-                    if (!this.pageEventsMapping[JournifyDefaultEvent.PAGE]){
-                        this.pageEventsMapping[JournifyDefaultEvent.PAGE] = [];
-                    }
-                    this.pageEventsMapping[JournifyDefaultEvent.PAGE].push(pixelMapping);
-                    break;
-
-                case TrackingEventType.GROUP_EVENT:
-                    if (!this.groupEventsMapping[JournifyDefaultEvent.GROUP]){
-                        this.groupEventsMapping[JournifyDefaultEvent.GROUP] = [];
-                    }
-                    this.groupEventsMapping[JournifyDefaultEvent.GROUP].push(pixelMapping);
-                    break;
-
-                case TrackingEventType.IDENTIFY_EVENT:
-                    if (!this.identifyEventsMapping[JournifyDefaultEvent.IDENTIFY]){
-                        this.identifyEventsMapping[JournifyDefaultEvent.IDENTIFY] = [];
-                    }
-                    this.identifyEventsMapping[JournifyDefaultEvent.IDENTIFY].push(pixelMapping);
-                    break;
-            }
-        }
+    if (!eventMappings || eventMappings.length === 0) {
+      return null;
     }
+
+    for (const mapping of eventMappings) {
+      if (matchFilters(event, mapping.filters)) {
+        return {
+          pixelEventName: mapping.pixelEventName,
+        };
+      }
+    }
+
+    return null;
+  }
+
+  private init(): void {
+    for (const mapping of this.eventMappings) {
+      if (!mapping.enabled) {
+        continue;
+      }
+
+      const pixelMapping: PixelEventMapping = {
+        pixelEventName: mapping.destination_event_key,
+        filters: mapping.filters,
+      };
+
+      switch (mapping.event_type) {
+        case TrackingEventType.TRACK_EVENT:
+          if (!this.trackEventsMapping[mapping.event_name]) {
+            this.trackEventsMapping[mapping.event_name] = [];
+          }
+          this.trackEventsMapping[mapping.event_name].push(pixelMapping);
+          break;
+
+        case TrackingEventType.PAGE_EVENT:
+          if (!this.pageEventsMapping[JournifyDefaultEvent.PAGE]) {
+            this.pageEventsMapping[JournifyDefaultEvent.PAGE] = [];
+          }
+          this.pageEventsMapping[JournifyDefaultEvent.PAGE].push(pixelMapping);
+          break;
+
+        case TrackingEventType.GROUP_EVENT:
+          if (!this.groupEventsMapping[JournifyDefaultEvent.GROUP]) {
+            this.groupEventsMapping[JournifyDefaultEvent.GROUP] = [];
+          }
+          this.groupEventsMapping[JournifyDefaultEvent.GROUP].push(
+            pixelMapping,
+          );
+          break;
+
+        case TrackingEventType.IDENTIFY_EVENT:
+          if (!this.identifyEventsMapping[JournifyDefaultEvent.IDENTIFY]) {
+            this.identifyEventsMapping[JournifyDefaultEvent.IDENTIFY] = [];
+          }
+          this.identifyEventsMapping[JournifyDefaultEvent.IDENTIFY].push(
+            pixelMapping,
+          );
+          break;
+      }
+    }
+  }
 }
 
 function matchFilters(event: object, filters: EventFilter[]): boolean {
-    if (filters) {
-        for (const filter of filters) {
-            if (!matchFilter(event, filter)) {
-                return false;
-            }
-        }
+  if (filters) {
+    for (const filter of filters) {
+      if (!matchFilter(event, filter)) {
+        return false;
+      }
     }
+  }
 
-    return true;
-}
-
-function coerceToType(value: string, target: unknown): unknown {
-    if (target === null || target === undefined) {
-        return value;
-    }
-    switch (typeof target) {
-        case 'number': {
-            const num = Number(value);
-            return isNaN(num) ? value : num;
-        }
-        case 'boolean':
-            return value === 'true' ? true : value === 'false' ? false : value;
-        default:
-            return value;
-    }
+  return true;
 }
 
 function matchFilter(event: object, filter: EventFilter): boolean {
-    const eventValue = getValue(event, filter.field);
-    const coercedFilterValue = coerceToType(filter.value, eventValue);
-    switch (filter.operator) {
-        case FilterOperator.EQUALS:
-            if (coercedFilterValue === eventValue) {
-                return true;
-            }
+  const eventValue = getValue(event, filter.field);
+  const coercedFilterValue = coerceToType(filter.value, eventValue);
+  switch (filter.operator) {
+    case FilterOperator.EQUALS:
+      if (coercedFilterValue === eventValue) {
+        return true;
+      }
 
-            return filter.value?.includes(eventValue);
+      return filter.value?.includes(eventValue);
 
-        case FilterOperator.NOT_EQUALS:
-            return coercedFilterValue !== eventValue;
+    case FilterOperator.NOT_EQUALS:
+      return coercedFilterValue !== eventValue;
 
-        case FilterOperator.CONTAINS:
-            return eventValue?.includes(filter.value);
+    case FilterOperator.CONTAINS:
+      return eventValue?.includes(filter.value);
 
-        case FilterOperator.NOT_CONTAINS:
-            return !eventValue?.includes(filter.value);
+    case FilterOperator.NOT_CONTAINS:
+      return !eventValue?.includes(filter.value);
 
-        case FilterOperator.STARTS_WITH:
-            return eventValue?.startsWith(filter.value);
+    case FilterOperator.STARTS_WITH:
+      return eventValue?.startsWith(filter.value);
 
-        case FilterOperator.ENDS_WITH:
-            return eventValue?.endsWith(filter.value);
+    case FilterOperator.ENDS_WITH:
+      return eventValue?.endsWith(filter.value);
 
-        case FilterOperator.GREATER_THAN:
-            return eventValue > coercedFilterValue;
+    case FilterOperator.GREATER_THAN:
+      return eventValue > coercedFilterValue;
 
-        case FilterOperator.GREATER_THAN_OR_EQ:
-            return eventValue >= coercedFilterValue;
+    case FilterOperator.GREATER_THAN_OR_EQ:
+      return eventValue >= coercedFilterValue;
 
-        case FilterOperator.LESS_THAN:
-            return eventValue < coercedFilterValue;
+    case FilterOperator.LESS_THAN:
+      return eventValue < coercedFilterValue;
 
-        case FilterOperator.LESS_THAN_OR_EQ:
-            return eventValue <= coercedFilterValue;
-    }
+    case FilterOperator.LESS_THAN_OR_EQ:
+      return eventValue <= coercedFilterValue;
+  }
 
-    return false;
+  return false;
 }


### PR DESCRIPTION
# Description

- Fix type mismatch in matchFilter where filter.value (always stored as a string from writeSettings) was compared with strict equality against eventValue which could be a number or boolean, causing filters with EQUALS, NOT_EQUALS, and numeric operators to silently fail
- Add coerceToType helper that converts the string filter.value to match the runtime type of eventValue (number, boolean) before comparison
- Add 41 tests covering type coercion, all filter operators, and edge cases

## Test plan
- [x] All existing tests pass (8 tests)
- [x] Type coercion tests: string filter values correctly match numeric event values ("42" === 42)
- [x] Type coercion tests: string filter values correctly match boolean event values ("true" === true)
- [x] Numeric comparison operators (>, >=, <, <=) work with string filter values against numeric event values
- [x] String operators (CONTAINS, NOT_CONTAINS, STARTS_WITH, ENDS_WITH) still work as before
- [x] Edge cases: undefined values, deeply nested fields, 0, negative numbers, multiple AND filters

# Github Issue(s)


---
***When reviewing this PR, please adhere to [conventional comments](https://conventionalcomments.org).***
