### PR TITLE
Npm registry OIDC

### DIFF
--- a/.github/workflows/merge_to_main.yaml
+++ b/.github/workflows/merge_to_main.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/publish_branch_staging.yaml
+++ b/.github/workflows/publish_branch_staging.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: "${{ github.event.inputs.branch }}"

--- a/.github/workflows/publish_production.yaml
+++ b/.github/workflows/publish_production.yaml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/publish_production.yaml
+++ b/.github/workflows/publish_production.yaml
@@ -23,9 +23,10 @@ jobs:
           fetch-depth: 0
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 21
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install modules
         run: yarn install

--- a/.github/workflows/publish_production.yaml
+++ b/.github/workflows/publish_production.yaml
@@ -75,13 +75,7 @@ jobs:
           headers: |-
             content-type: 'text/javascript; charset=utf-8'
 
-      - name: Publish to npm
-        uses: JS-DevTools/npm-publish@v1
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
-          access: public
-
-  
+      - run: npm publish --access public
 
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v2'

--- a/.github/workflows/publish_version_staging.yaml
+++ b/.github/workflows/publish_version_staging.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
remove NPM token based Auth and use OIDC (trusted publisher already configured on NPM registry for this repo)