### PR TITLE
feat: add ws consent mode handling

### DIFF
--- a/src/lib/api/loader.ts
+++ b/src/lib/api/loader.ts
@@ -82,7 +82,9 @@ export class Loader {
 
     if (!this.consentService) {
       const initialConsent = sdkConfig.options?.initialConsent;
-      const workspaceConsentMode = writeKeySettings.syncs?.[0]?.workspace_consent_mode;
+      const workspaceConsentMode = writeKeySettings.syncs
+          ?.find((sync) => sync?.workspace_consent_mode !== undefined)
+          ?.workspace_consent_mode;
       const consentMode = resolveConsentMode(writeKeySettings.countryCode, workspaceConsentMode);
       this.consentService = new ConsentServiceImpl(consentMode, initialConsent);
     }

--- a/src/lib/api/loader.ts
+++ b/src/lib/api/loader.ts
@@ -39,7 +39,7 @@ import {GoogleAdsGtag} from "../transport/plugins/google_ads_gtag/googleAdsGtag"
 import {LinkedinAdsInsightTag} from "../transport/plugins/linkedin_ads_insight_tag/linkedinAdsInsightTag";
 import {FieldsMapperFactoryImpl} from "../transport/plugins/lib/fieldMapping";
 import {EventMapperFactoryImpl} from "../transport/plugins/lib/eventMapping";
-import {ConsentServiceImpl, ConsentService, ConsentCategoryPreferences} from "../domain/consent";
+import {ConsentServiceImpl, ConsentService, ConsentCategoryPreferences, resolveConsentMode} from "../domain/consent";
 
 const INTEGRATION_PLUGINS = {
   bing_ads_tag: BingAdsTag,
@@ -82,10 +82,9 @@ export class Loader {
 
     if (!this.consentService) {
       const initialConsent = sdkConfig.options?.initialConsent;
-      this.consentService = new ConsentServiceImpl(
-          writeKeySettings.countryCode,
-          initialConsent
-      );
+      const workspaceConsentMode = writeKeySettings.syncs?.[0]?.workspace_consent_mode;
+      const consentMode = resolveConsentMode(writeKeySettings.countryCode, workspaceConsentMode);
+      this.consentService = new ConsentServiceImpl(consentMode, initialConsent);
     }
 
     const browser = new BrowserImpl();

--- a/src/lib/domain/_tests/consent.test.ts
+++ b/src/lib/domain/_tests/consent.test.ts
@@ -265,7 +265,6 @@ describe("ConsentService interface", () => {
                 };
                 const consentService = new ConsentServiceImpl('strict', initialConsent);
 
-                expect(consentService.hasConsent('')).toBe(false);
                 expect(consentService.hasConsent(undefined)).toBe(false);
                 expect(consentService.hasConsent(null)).toBe(false);
             })
@@ -327,7 +326,6 @@ describe("ConsentService interface", () => {
                 };
                 const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
-                expect(consentService.hasConsent('')).toBe(true);
                 expect(consentService.hasConsent(undefined)).toBe(true);
                 expect(consentService.hasConsent(null)).toBe(true);
             })

--- a/src/lib/domain/_tests/consent.test.ts
+++ b/src/lib/domain/_tests/consent.test.ts
@@ -1,59 +1,54 @@
-import {ConsentServiceImpl, ConsentCategoryPreferences, ConsentPreference} from "../consent";
+import {ConsentServiceImpl, ConsentCategoryPreferences, ConsentPreference, resolveConsentMode} from "../consent";
+
+describe("resolveConsentMode function", () => {
+    describe("workspace consent mode", () => {
+        it("Should return workspaceConsentMode when provided, regardless of country", () => {
+            expect(resolveConsentMode('US', 'strict')).toBe('strict');
+            expect(resolveConsentMode('FR', 'relaxed')).toBe('relaxed');
+        })
+
+        it("Should return workspaceConsentMode when country is undefined", () => {
+            expect(resolveConsentMode(undefined, 'strict')).toBe('strict');
+            expect(resolveConsentMode(undefined, 'relaxed')).toBe('relaxed');
+        })
+    })
+
+    describe("country-based fallback", () => {
+        it("Should return 'strict' for GDPR countries", () => {
+            expect(resolveConsentMode('FR')).toBe('strict');
+            expect(resolveConsentMode('DE')).toBe('strict');
+            expect(resolveConsentMode('GB')).toBe('strict');
+        })
+
+        it("Should return 'relaxed' for non-GDPR countries", () => {
+            expect(resolveConsentMode('US')).toBe('relaxed');
+            expect(resolveConsentMode('SA')).toBe('relaxed');
+        })
+
+        it("Should return 'relaxed' for empty or undefined country", () => {
+            expect(resolveConsentMode('')).toBe('relaxed');
+            expect(resolveConsentMode(undefined)).toBe('relaxed');
+        })
+
+        it("Should normalize lowercase country codes", () => {
+            expect(resolveConsentMode('fr')).toBe('strict');
+            expect(resolveConsentMode('de')).toBe('strict');
+            expect(resolveConsentMode('us')).toBe('relaxed');
+        })
+
+        it("Should trim whitespace from country codes", () => {
+            expect(resolveConsentMode(' FR ')).toBe('strict');
+            expect(resolveConsentMode('  DE')).toBe('strict');
+            expect(resolveConsentMode('US  ')).toBe('relaxed');
+        })
+    })
+})
 
 describe("ConsentServiceImpl class", () => {
     describe("constructor", () => {
-        describe("consent mode determination based on country", () => {
-            it.skip("Should use 'strict' mode for GDPR countries (e.g., 'DE', 'FR', 'GB')", () => {
-                const consentService = new ConsentServiceImpl('FR');
-
-                // In strict mode with no config, hasConsent should return false
-                expect(consentService.hasConsent('analytics')).toBe(false);
-            })
-
-            it("Should use 'relaxed' mode for non-GDPR countries (e.g., 'US', 'SA')", () => {
-                const consentService = new ConsentServiceImpl('SA');
-
-                // In relaxed mode with no config, hasConsent should return true
-                expect(consentService.hasConsent('analytics')).toBe(true);
-            })
-
-            it("Should use 'relaxed' mode for empty/undefined country", () => {
-                let consentService = new ConsentServiceImpl('');
-                expect(consentService.hasConsent('analytics')).toBe(true);
-
-                consentService = new ConsentServiceImpl(undefined);
-                expect(consentService.hasConsent('analytics')).toBe(true);
-            })
-
-            it.skip("Should normalize lowercase country codes", () => {
-                // GDPR countries in lowercase should still trigger strict mode
-                let consentService = new ConsentServiceImpl('fr');
-                expect(consentService.hasConsent('analytics')).toBe(false);
-
-                consentService = new ConsentServiceImpl('de');
-                expect(consentService.hasConsent('analytics')).toBe(false);
-
-                // Non-GDPR in lowercase should trigger relaxed mode
-                consentService = new ConsentServiceImpl('us');
-                expect(consentService.hasConsent('analytics')).toBe(true);
-            })
-
-            it.skip("Should trim whitespace from country codes", () => {
-                let consentService = new ConsentServiceImpl(' FR ');
-                expect(consentService.hasConsent('analytics')).toBe(false);
-
-                consentService = new ConsentServiceImpl('  DE');
-                expect(consentService.hasConsent('analytics')).toBe(false);
-
-                consentService = new ConsentServiceImpl('US  ');
-                expect(consentService.hasConsent('analytics')).toBe(true);
-            })
-
-        })
-
         describe("initial consent", () => {
             it("Should initialize with all UNSPECIFIED when no initialConsent provided", () => {
-                const consentService = new ConsentServiceImpl('US');
+                const consentService = new ConsentServiceImpl('relaxed');
 
                 const consent = consentService.getConsent();
 
@@ -75,7 +70,7 @@ describe("ConsentServiceImpl class", () => {
                     marketing: ConsentPreference.UNSPECIFIED,
                     personalization: ConsentPreference.UNSPECIFIED,
                 };
-                const consentService = new ConsentServiceImpl('FR', initialConsent);
+                const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
                 const consent = consentService.getConsent();
 
@@ -97,7 +92,7 @@ describe("ConsentServiceImpl class", () => {
                     marketing: ConsentPreference.DENIED,
                     personalization: ConsentPreference.GRANTED,
                 };
-                const consentService = new ConsentServiceImpl('FR', initialConsent);
+                const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
                 const consent = consentService.getConsent();
 
@@ -118,7 +113,7 @@ describe("ConsentServiceImpl class", () => {
                     marketing: ConsentPreference.UNSPECIFIED,
                     personalization: ConsentPreference.UNSPECIFIED,
                 };
-                const consentService = new ConsentServiceImpl('FR', initialConsent);
+                const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
                 consentService.updateConsent({
                     advertising: ConsentPreference.UNSPECIFIED,
@@ -145,7 +140,7 @@ describe("ConsentService interface", () => {
                 marketing: ConsentPreference.UNSPECIFIED,
                 personalization: ConsentPreference.UNSPECIFIED,
             };
-            const consentService = new ConsentServiceImpl('FR', initialConsent);
+            const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
             expect(consentService.getConsent().categoryPreferences.advertising).toBe(ConsentPreference.DENIED);
             expect(consentService.getConsent().categoryPreferences.analytics).toBe(ConsentPreference.DENIED);
@@ -170,7 +165,7 @@ describe("ConsentService interface", () => {
                 marketing: ConsentPreference.UNSPECIFIED,
                 personalization: ConsentPreference.UNSPECIFIED,
             };
-            const consentService = new ConsentServiceImpl('FR', initialConsent);
+            const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
             consentService.updateConsent({
                 advertising: ConsentPreference.GRANTED,
@@ -197,7 +192,7 @@ describe("ConsentService interface", () => {
                 marketing: ConsentPreference.DENIED,
                 personalization: ConsentPreference.UNSPECIFIED,
             };
-            const consentService = new ConsentServiceImpl('FR', initialConsent);
+            const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
             consentService.updateConsent({
                 advertising: ConsentPreference.GRANTED,
@@ -224,7 +219,7 @@ describe("ConsentService interface", () => {
                 marketing: ConsentPreference.UNSPECIFIED,
                 personalization: ConsentPreference.UNSPECIFIED,
             };
-            const consentService = new ConsentServiceImpl('FR', initialConsent);
+            const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
             // TypeScript would catch this, but testing runtime behavior
             consentService.updateConsent({ invalid_category: ConsentPreference.GRANTED } as unknown as ConsentCategoryPreferences);
@@ -240,153 +235,133 @@ describe("ConsentService interface", () => {
     })
 
     describe("hasConsent method", () => {
-        // Strict mode tests (GDPR country)
-        it.skip("Should return false in strict mode when no categories configured", () => {
-            const consentService = new ConsentServiceImpl('FR');
+        describe("strict mode", () => {
+            it("Should return false when no categories configured", () => {
+                const consentService = new ConsentServiceImpl('strict');
 
-            const result = consentService.hasConsent('analytics');
-            expect(result).toBe(false);
+                expect(consentService.hasConsent('analytics')).toBe(false);
+            })
+
+            it("Should return false when category is UNSPECIFIED", () => {
+                const initialConsent: ConsentCategoryPreferences = {
+                    advertising: ConsentPreference.GRANTED,
+                    analytics: ConsentPreference.UNSPECIFIED,
+                    functional: ConsentPreference.UNSPECIFIED,
+                    marketing: ConsentPreference.UNSPECIFIED,
+                    personalization: ConsentPreference.UNSPECIFIED,
+                };
+                const consentService = new ConsentServiceImpl('strict', initialConsent);
+
+                expect(consentService.hasConsent('analytics')).toBe(false);
+            })
+
+            it("Should return false when destination category is empty or undefined", () => {
+                const initialConsent: ConsentCategoryPreferences = {
+                    advertising: ConsentPreference.UNSPECIFIED,
+                    analytics: ConsentPreference.GRANTED,
+                    functional: ConsentPreference.UNSPECIFIED,
+                    marketing: ConsentPreference.UNSPECIFIED,
+                    personalization: ConsentPreference.UNSPECIFIED,
+                };
+                const consentService = new ConsentServiceImpl('strict', initialConsent);
+
+                expect(consentService.hasConsent('')).toBe(false);
+                expect(consentService.hasConsent(undefined)).toBe(false);
+                expect(consentService.hasConsent(null)).toBe(false);
+            })
+
+            it("Should return true when category is explicitly GRANTED", () => {
+                const initialConsent: ConsentCategoryPreferences = {
+                    advertising: ConsentPreference.UNSPECIFIED,
+                    analytics: ConsentPreference.GRANTED,
+                    functional: ConsentPreference.UNSPECIFIED,
+                    marketing: ConsentPreference.UNSPECIFIED,
+                    personalization: ConsentPreference.UNSPECIFIED,
+                };
+                const consentService = new ConsentServiceImpl('strict', initialConsent);
+
+                expect(consentService.hasConsent('analytics')).toBe(true);
+            })
+
+            it("Should return false when category is explicitly DENIED", () => {
+                const initialConsent: ConsentCategoryPreferences = {
+                    advertising: ConsentPreference.UNSPECIFIED,
+                    analytics: ConsentPreference.DENIED,
+                    functional: ConsentPreference.UNSPECIFIED,
+                    marketing: ConsentPreference.UNSPECIFIED,
+                    personalization: ConsentPreference.UNSPECIFIED,
+                };
+                const consentService = new ConsentServiceImpl('strict', initialConsent);
+
+                expect(consentService.hasConsent('analytics')).toBe(false);
+            })
         })
 
-        it.skip("Should return false in strict mode when category is UNSPECIFIED", () => {
-            const initialConsent: ConsentCategoryPreferences = {
-                advertising: ConsentPreference.GRANTED,
-                analytics: ConsentPreference.UNSPECIFIED,
-                functional: ConsentPreference.UNSPECIFIED,
-                marketing: ConsentPreference.UNSPECIFIED,
-                personalization: ConsentPreference.UNSPECIFIED,
-            };
-            const consentService = new ConsentServiceImpl('FR', initialConsent);
+        describe("relaxed mode", () => {
+            it("Should return true when no categories configured", () => {
+                const consentService = new ConsentServiceImpl('relaxed');
 
-            const result = consentService.hasConsent('analytics');
-            expect(result).toBe(false);
-        })
+                expect(consentService.hasConsent('analytics')).toBe(true);
+            })
 
-        it("Should return false when category is explicitly DENIED", () => {
-            const initialConsent: ConsentCategoryPreferences = {
-                advertising: ConsentPreference.UNSPECIFIED,
-                analytics: ConsentPreference.DENIED,
-                functional: ConsentPreference.UNSPECIFIED,
-                marketing: ConsentPreference.UNSPECIFIED,
-                personalization: ConsentPreference.UNSPECIFIED,
-            };
-            const consentService = new ConsentServiceImpl('FR', initialConsent);
+            it("Should return true when category is UNSPECIFIED", () => {
+                const initialConsent: ConsentCategoryPreferences = {
+                    advertising: ConsentPreference.GRANTED,
+                    analytics: ConsentPreference.UNSPECIFIED,
+                    functional: ConsentPreference.UNSPECIFIED,
+                    marketing: ConsentPreference.UNSPECIFIED,
+                    personalization: ConsentPreference.UNSPECIFIED,
+                };
+                const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
-            const result = consentService.hasConsent('analytics');
-            expect(result).toBe(false);
-        })
+                expect(consentService.hasConsent('analytics')).toBe(true);
+            })
 
-        it("Should return true when category is GRANTED", () => {
-            const initialConsent: ConsentCategoryPreferences = {
-                advertising: ConsentPreference.UNSPECIFIED,
-                analytics: ConsentPreference.GRANTED,
-                functional: ConsentPreference.UNSPECIFIED,
-                marketing: ConsentPreference.UNSPECIFIED,
-                personalization: ConsentPreference.UNSPECIFIED,
-            };
-            const consentService = new ConsentServiceImpl('FR', initialConsent);
+            it("Should return true when destination category is empty or undefined", () => {
+                const initialConsent: ConsentCategoryPreferences = {
+                    advertising: ConsentPreference.UNSPECIFIED,
+                    analytics: ConsentPreference.DENIED,
+                    functional: ConsentPreference.UNSPECIFIED,
+                    marketing: ConsentPreference.UNSPECIFIED,
+                    personalization: ConsentPreference.UNSPECIFIED,
+                };
+                const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
-            const result = consentService.hasConsent('analytics');
-            expect(result).toBe(true);
-        })
+                expect(consentService.hasConsent('')).toBe(true);
+                expect(consentService.hasConsent(undefined)).toBe(true);
+                expect(consentService.hasConsent(null)).toBe(true);
+            })
 
-        it.skip("Should return false in strict mode when category preference is UNSPECIFIED", () => {
-            const initialConsent: ConsentCategoryPreferences = {
-                advertising: ConsentPreference.UNSPECIFIED,
-                analytics: ConsentPreference.UNSPECIFIED,
-                functional: ConsentPreference.UNSPECIFIED,
-                marketing: ConsentPreference.UNSPECIFIED,
-                personalization: ConsentPreference.UNSPECIFIED,
-            };
-            const consentService = new ConsentServiceImpl('FR', initialConsent);
+            it("Should return true when category is GRANTED", () => {
+                const initialConsent: ConsentCategoryPreferences = {
+                    advertising: ConsentPreference.UNSPECIFIED,
+                    analytics: ConsentPreference.GRANTED,
+                    functional: ConsentPreference.UNSPECIFIED,
+                    marketing: ConsentPreference.UNSPECIFIED,
+                    personalization: ConsentPreference.UNSPECIFIED,
+                };
+                const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
-            const result = consentService.hasConsent('analytics');
-            expect(result).toBe(false);
-        })
+                expect(consentService.hasConsent('analytics')).toBe(true);
+            })
 
-        it("Should return true in relaxed mode when category preference is UNSPECIFIED", () => {
-            const initialConsent: ConsentCategoryPreferences = {
-                advertising: ConsentPreference.UNSPECIFIED,
-                analytics: ConsentPreference.UNSPECIFIED,
-                functional: ConsentPreference.UNSPECIFIED,
-                marketing: ConsentPreference.UNSPECIFIED,
-                personalization: ConsentPreference.UNSPECIFIED,
-            };
-            const consentService = new ConsentServiceImpl('US', initialConsent);
+            it("Should return false when category is explicitly DENIED", () => {
+                const initialConsent: ConsentCategoryPreferences = {
+                    advertising: ConsentPreference.UNSPECIFIED,
+                    analytics: ConsentPreference.DENIED,
+                    functional: ConsentPreference.UNSPECIFIED,
+                    marketing: ConsentPreference.UNSPECIFIED,
+                    personalization: ConsentPreference.UNSPECIFIED,
+                };
+                const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
-            const result = consentService.hasConsent('analytics');
-            expect(result).toBe(true);
-        })
-
-        it.skip("Should return false in strict mode when destination category is empty or undefined", () => {
-            const initialConsent: ConsentCategoryPreferences = {
-                advertising: ConsentPreference.UNSPECIFIED,
-                analytics: ConsentPreference.GRANTED,
-                functional: ConsentPreference.UNSPECIFIED,
-                marketing: ConsentPreference.UNSPECIFIED,
-                personalization: ConsentPreference.UNSPECIFIED,
-            };
-            const consentService = new ConsentServiceImpl('FR', initialConsent);
-
-            expect(consentService.hasConsent('')).toBe(false);
-            expect(consentService.hasConsent(undefined)).toBe(false);
-            expect(consentService.hasConsent(null)).toBe(false);
-        })
-
-        // Relaxed mode tests (non-GDPR country)
-        it("Should return true in relaxed mode when no categories configured", () => {
-            const consentService = new ConsentServiceImpl('US');
-
-            const result = consentService.hasConsent('analytics');
-            expect(result).toBe(true);
-        })
-
-        it("Should return true in relaxed mode when category is UNSPECIFIED", () => {
-            const initialConsent: ConsentCategoryPreferences = {
-                advertising: ConsentPreference.GRANTED,
-                analytics: ConsentPreference.UNSPECIFIED,
-                functional: ConsentPreference.UNSPECIFIED,
-                marketing: ConsentPreference.UNSPECIFIED,
-                personalization: ConsentPreference.UNSPECIFIED,
-            };
-            const consentService = new ConsentServiceImpl('US', initialConsent);
-
-            const result = consentService.hasConsent('analytics');
-            expect(result).toBe(true);
-        })
-
-        it("Should return false in relaxed mode when category is explicitly DENIED", () => {
-            const initialConsent: ConsentCategoryPreferences = {
-                advertising: ConsentPreference.UNSPECIFIED,
-                analytics: ConsentPreference.DENIED,
-                functional: ConsentPreference.UNSPECIFIED,
-                marketing: ConsentPreference.UNSPECIFIED,
-                personalization: ConsentPreference.UNSPECIFIED,
-            };
-            const consentService = new ConsentServiceImpl('US', initialConsent);
-
-            const result = consentService.hasConsent('analytics');
-            expect(result).toBe(false);
-        })
-
-        it("Should return true in relaxed mode when destination category is empty or undefined", () => {
-            const initialConsent: ConsentCategoryPreferences = {
-                advertising: ConsentPreference.UNSPECIFIED,
-                analytics: ConsentPreference.DENIED,
-                functional: ConsentPreference.UNSPECIFIED,
-                marketing: ConsentPreference.UNSPECIFIED,
-                personalization: ConsentPreference.UNSPECIFIED,
-            };
-            const consentService = new ConsentServiceImpl('US', initialConsent);
-
-            expect(consentService.hasConsent('')).toBe(true);
-            expect(consentService.hasConsent(undefined)).toBe(true);
-            expect(consentService.hasConsent(null)).toBe(true);
+                expect(consentService.hasConsent('analytics')).toBe(false);
+            })
         })
     })
 
     describe("getConsent method", () => {
-        it("Should return the current consent object with country", () => {
+        it("Should return the current consent object", () => {
             const initialConsent: ConsentCategoryPreferences = {
                 advertising: ConsentPreference.DENIED,
                 analytics: ConsentPreference.GRANTED,
@@ -394,7 +369,7 @@ describe("ConsentService interface", () => {
                 marketing: ConsentPreference.UNSPECIFIED,
                 personalization: ConsentPreference.UNSPECIFIED,
             };
-            const consentService = new ConsentServiceImpl('FR', initialConsent);
+            const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
             const consent = consentService.getConsent();
 
@@ -417,7 +392,7 @@ describe("ConsentService interface", () => {
                 marketing: ConsentPreference.UNSPECIFIED,
                 personalization: ConsentPreference.UNSPECIFIED,
             };
-            const consentService = new ConsentServiceImpl('FR', initialConsent);
+            const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
             expect(consentService.getConsent().categoryPreferences.analytics).toBe(ConsentPreference.DENIED);
 

--- a/src/lib/domain/consent.ts
+++ b/src/lib/domain/consent.ts
@@ -43,7 +43,7 @@ export type ConsentState = {
 
 export interface ConsentService {
     updateConsent(categoryPreferences: ConsentCategoryPreferences): void;
-    hasConsent(destinationCategory: string): boolean;
+    hasConsent(destinationCategory: ConsentCategory): boolean;
     getConsent(): Consent;
 }
 
@@ -56,9 +56,13 @@ const DEFAULT_CONSENT: ConsentCategoryPreferences = {
 };
 
 export function resolveConsentMode(country?: string, workspaceConsentMode?: ConsentMode): ConsentMode {
-    if (workspaceConsentMode) return workspaceConsentMode;
+    if (isConsentMode(workspaceConsentMode)) return workspaceConsentMode;
     const normalizedCountry = country?.trim().toUpperCase() || '';
     return GDPR_COUNTRIES.has(normalizedCountry) ? STRICT_MODE : RELAXED_MODE;
+}
+
+function isConsentMode(value?: string): value is ConsentMode {
+    return value === STRICT_MODE || value === RELAXED_MODE;
 }
 
 export class ConsentServiceImpl implements ConsentService {
@@ -89,7 +93,7 @@ export class ConsentServiceImpl implements ConsentService {
     }
 
     // Method that checks if consent is given for the specified category
-    public hasConsent(destinationCategory: string): boolean {
+    public hasConsent(destinationCategory: ConsentCategory): boolean {
         const consentMode = this.consentState.consentMode;
         const categoryPreferences = this.consentState.consent.categoryPreferences;
 

--- a/src/lib/domain/consent.ts
+++ b/src/lib/domain/consent.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const STRICT_MODE = 'strict';
 const RELAXED_MODE = 'relaxed';
 
@@ -19,6 +18,8 @@ const GDPR_COUNTRIES = new Set([
 
 export const CONSENT_CATEGORIES = ['advertising', 'analytics', 'functional', 'marketing', 'personalization'] as const;
 
+export type ConsentCategory = typeof CONSENT_CATEGORIES[number];
+
 export type ConsentMode = typeof STRICT_MODE | typeof RELAXED_MODE;
 
 export enum ConsentPreference {
@@ -28,7 +29,7 @@ export enum ConsentPreference {
 }
 
 export type ConsentCategoryPreferences = {
-    [K in typeof CONSENT_CATEGORIES[number]]: ConsentPreference;
+    [K in typeof CONSENT_CATEGORIES[number]]?: ConsentPreference;
 };
 
 export type Consent = {
@@ -54,28 +55,25 @@ const DEFAULT_CONSENT: ConsentCategoryPreferences = {
     personalization: ConsentPreference.UNSPECIFIED,
 };
 
+export function resolveConsentMode(country?: string, workspaceConsentMode?: ConsentMode): ConsentMode {
+    if (workspaceConsentMode) return workspaceConsentMode;
+    const normalizedCountry = country?.trim().toUpperCase() || '';
+    return GDPR_COUNTRIES.has(normalizedCountry) ? STRICT_MODE : RELAXED_MODE;
+}
+
 export class ConsentServiceImpl implements ConsentService {
     private readonly consentState: ConsentState;
 
     constructor(
-        country: string,
+        consentMode: ConsentMode,
         initialConsent?: ConsentCategoryPreferences
     ) {
-        const consentMode = this.getConsentMode(country);
         this.consentState = {
             consentMode,
             consent: {
-                categoryPreferences: initialConsent ? { ...initialConsent } : { ...DEFAULT_CONSENT },
+                categoryPreferences: { ...DEFAULT_CONSENT, ...initialConsent },
             }
         };
-    }
-
-    // Determine consent mode based on country
-    private getConsentMode(country?: string): ConsentMode {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const normalizedCountry = country?.trim().toUpperCase() || ''
-        //return GDPR_COUNTRIES.has(normalizedCountry) ? STRICT_MODE : RELAXED_MODE;
-        return RELAXED_MODE; // temporarily set every country to relaxed mode
     }
 
     public updateConsent(categoryPreferences: ConsentCategoryPreferences): void {
@@ -101,11 +99,10 @@ export class ConsentServiceImpl implements ConsentService {
 
         const preference = categoryPreferences[destinationCategory];
 
-        // If category has no explicit consent decision
-        if (preference === ConsentPreference.UNSPECIFIED) {
-            return consentMode === RELAXED_MODE; // Strict mode requires explicit consent, relaxed mode assumes consent
-        }
+        if (preference === ConsentPreference.GRANTED) return true;
+        if (preference === ConsentPreference.DENIED) return false;
 
-        return preference === ConsentPreference.GRANTED;
+        // Anything else (UNSPECIFIED or unrecognized value) falls back to mode
+        return consentMode === RELAXED_MODE;
     }
 }

--- a/src/lib/transport/plugins/plugin.ts
+++ b/src/lib/transport/plugins/plugin.ts
@@ -6,7 +6,7 @@ import { FieldsMapperFactory } from "./lib/fieldMapping";
 import { HttpCookieOptions } from "../../lib/httpCookieService";
 import { User } from "../../domain/user";
 import { SentryWrapper } from "../../lib/sentry";
-import {ConsentCategoryPreferences} from "../../domain/consent";
+import {ConsentCategoryPreferences, ConsentCategory, ConsentMode} from "../../domain/consent";
 
 export interface Plugin {
   name: string;
@@ -64,7 +64,8 @@ export interface WriteKeySettings {
 export interface Sync {
   id: string;
   destination_app: string;
-  destination_consent_category?: string;
+  destination_consent_category?: ConsentCategory;
+  workspace_consent_mode?: ConsentMode;
   settings: SyncSetting[];
   field_mappings: FieldMapping[];
   event_mappings: EventMapping[];

--- a/src/test/mocks/consentService.ts
+++ b/src/test/mocks/consentService.ts
@@ -1,4 +1,4 @@
-import {Consent, ConsentCategoryPreferences, ConsentPreference, ConsentService} from "../../lib/domain/consent";
+import {Consent, ConsentCategory, ConsentCategoryPreferences, ConsentPreference, ConsentService} from "../../lib/domain/consent";
 
 export class ConsentServiceMock implements ConsentService {
     public funcs: ConsentServiceMockFuncs;
@@ -21,7 +21,7 @@ export class ConsentServiceMock implements ConsentService {
         }
     }
 
-    hasConsent(destinationCategory: string): boolean {
+    hasConsent(destinationCategory: ConsentCategory): boolean {
         if (this.funcs?.hasConsent) {
             return this.funcs.hasConsent(destinationCategory);
         }


### PR DESCRIPTION
# Description
-  Add `workspace_consent_mode` in Syncs
- Handle ws consent mode setting to determine the consent mode in Consent init
- Refactor `destination_consent_category` type to be `ConsentCategory` instead of plain string

# Linear Issue
[PRO-790](https://linear.app/journify-infra/issue/PRO-790/add-workspace-setting-to-update-consent-mode)


---
***When reviewing this PR, please adhere to [conventional comments](https://conventionalcomments.org).***
