### PR TITLE
[PATCH] Add consent mode workspace setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@journifyio/js-sdk",
-  "version": "0.0.214",
+  "version": "0.0.211",
   "description": "Journify SDK in JavaScript",
   "main": "dist/lib/es5/index.js",
   "types": "dist/lib/es5/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@journifyio/js-sdk",
-  "version": "0.0.212",
+  "version": "0.0.213",
   "description": "Journify SDK in JavaScript",
   "main": "dist/lib/es5/index.js",
   "types": "dist/lib/es5/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@journifyio/js-sdk",
-  "version": "0.0.211",
+  "version": "0.0.212",
   "description": "Journify SDK in JavaScript",
   "main": "dist/lib/es5/index.js",
   "types": "dist/lib/es5/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@journifyio/js-sdk",
-  "version": "0.0.210",
+  "version": "0.0.211",
   "description": "Journify SDK in JavaScript",
   "main": "dist/lib/es5/index.js",
   "types": "dist/lib/es5/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@journifyio/js-sdk",
-  "version": "0.0.213",
+  "version": "0.0.214",
   "description": "Journify SDK in JavaScript",
   "main": "dist/lib/es5/index.js",
   "types": "dist/lib/es5/index.d.ts",

--- a/src/lib/api/loader.ts
+++ b/src/lib/api/loader.ts
@@ -82,10 +82,8 @@ export class Loader {
 
     if (!this.consentService) {
       const initialConsent = sdkConfig.options?.initialConsent;
-      const workspaceConsentMode = writeKeySettings.syncs
-          ?.find((sync) => sync?.workspace_consent_mode !== undefined)
-          ?.workspace_consent_mode;
-      const consentMode = resolveConsentMode(writeKeySettings.countryCode, workspaceConsentMode);
+      const workspaceConsentMode = writeKeySettings.workspace_consent_mode;
+      const consentMode = resolveConsentMode(writeKeySettings.country_code, workspaceConsentMode);
       this.consentService = new ConsentServiceImpl(consentMode, initialConsent);
     }
 

--- a/src/lib/api/loader.ts
+++ b/src/lib/api/loader.ts
@@ -82,7 +82,9 @@ export class Loader {
 
     if (!this.consentService) {
       const initialConsent = sdkConfig.options?.initialConsent;
-      const workspaceConsentMode = writeKeySettings.syncs?.[0]?.workspace_consent_mode;
+      const workspaceConsentMode = writeKeySettings.syncs
+          ?.find((sync) => sync?.workspace_consent_mode !== undefined)
+          ?.workspace_consent_mode;
       const consentMode = resolveConsentMode(writeKeySettings.countryCode, workspaceConsentMode);
       this.consentService = new ConsentServiceImpl(consentMode, initialConsent);
     }

--- a/src/lib/api/loader.ts
+++ b/src/lib/api/loader.ts
@@ -39,7 +39,7 @@ import {GoogleAdsGtag} from "../transport/plugins/google_ads_gtag/googleAdsGtag"
 import {LinkedinAdsInsightTag} from "../transport/plugins/linkedin_ads_insight_tag/linkedinAdsInsightTag";
 import {FieldsMapperFactoryImpl} from "../transport/plugins/lib/fieldMapping";
 import {EventMapperFactoryImpl} from "../transport/plugins/lib/eventMapping";
-import {ConsentServiceImpl, ConsentService, ConsentCategoryPreferences} from "../domain/consent";
+import {ConsentServiceImpl, ConsentService, ConsentCategoryPreferences, resolveConsentMode} from "../domain/consent";
 
 const INTEGRATION_PLUGINS = {
   bing_ads_tag: BingAdsTag,
@@ -82,10 +82,9 @@ export class Loader {
 
     if (!this.consentService) {
       const initialConsent = sdkConfig.options?.initialConsent;
-      this.consentService = new ConsentServiceImpl(
-          writeKeySettings.countryCode,
-          initialConsent
-      );
+      const workspaceConsentMode = writeKeySettings.syncs?.[0]?.workspace_consent_mode;
+      const consentMode = resolveConsentMode(writeKeySettings.countryCode, workspaceConsentMode);
+      this.consentService = new ConsentServiceImpl(consentMode, initialConsent);
     }
 
     const browser = new BrowserImpl();

--- a/src/lib/api/loader.ts
+++ b/src/lib/api/loader.ts
@@ -82,7 +82,7 @@ export class Loader {
 
     if (!this.consentService) {
       const initialConsent = sdkConfig.options?.initialConsent;
-      const workspaceConsentMode = writeKeySettings.workspace_consent_mode;
+      const workspaceConsentMode = writeKeySettings.consent_mode;
       const consentMode = resolveConsentMode(writeKeySettings.country_code, workspaceConsentMode);
       this.consentService = new ConsentServiceImpl(consentMode, initialConsent);
     }

--- a/src/lib/api/loader.ts
+++ b/src/lib/api/loader.ts
@@ -82,8 +82,7 @@ export class Loader {
 
     if (!this.consentService) {
       const initialConsent = sdkConfig.options?.initialConsent;
-      const workspaceConsentMode = writeKeySettings.consent_mode;
-      const consentMode = resolveConsentMode(writeKeySettings.country_code, workspaceConsentMode);
+      const consentMode = resolveConsentMode(writeKeySettings.country_code, writeKeySettings.consent_mode);
       this.consentService = new ConsentServiceImpl(consentMode, initialConsent);
     }
 

--- a/src/lib/domain/_tests/consent.test.ts
+++ b/src/lib/domain/_tests/consent.test.ts
@@ -255,15 +255,8 @@ describe("ConsentService interface", () => {
                 expect(consentService.hasConsent('analytics')).toBe(false);
             })
 
-            it("Should return false when destination category is empty or undefined", () => {
-                const initialConsent: ConsentCategoryPreferences = {
-                    advertising: ConsentPreference.UNSPECIFIED,
-                    analytics: ConsentPreference.GRANTED,
-                    functional: ConsentPreference.UNSPECIFIED,
-                    marketing: ConsentPreference.UNSPECIFIED,
-                    personalization: ConsentPreference.UNSPECIFIED,
-                };
-                const consentService = new ConsentServiceImpl('strict', initialConsent);
+            it("Should return false when destination category is null or undefined", () => {
+                const consentService = new ConsentServiceImpl('strict');
 
                 expect(consentService.hasConsent(undefined)).toBe(false);
                 expect(consentService.hasConsent(null)).toBe(false);
@@ -316,15 +309,8 @@ describe("ConsentService interface", () => {
                 expect(consentService.hasConsent('analytics')).toBe(true);
             })
 
-            it("Should return true when destination category is empty or undefined", () => {
-                const initialConsent: ConsentCategoryPreferences = {
-                    advertising: ConsentPreference.UNSPECIFIED,
-                    analytics: ConsentPreference.DENIED,
-                    functional: ConsentPreference.UNSPECIFIED,
-                    marketing: ConsentPreference.UNSPECIFIED,
-                    personalization: ConsentPreference.UNSPECIFIED,
-                };
-                const consentService = new ConsentServiceImpl('relaxed', initialConsent);
+            it("Should return true when destination category is null or undefined", () => {
+                const consentService = new ConsentServiceImpl('relaxed');
 
                 expect(consentService.hasConsent(undefined)).toBe(true);
                 expect(consentService.hasConsent(null)).toBe(true);

--- a/src/lib/domain/_tests/consent.test.ts
+++ b/src/lib/domain/_tests/consent.test.ts
@@ -265,7 +265,6 @@ describe("ConsentService interface", () => {
                 };
                 const consentService = new ConsentServiceImpl('strict', initialConsent);
 
-                expect(consentService.hasConsent('')).toBe(false);
                 expect(consentService.hasConsent(undefined)).toBe(false);
                 expect(consentService.hasConsent(null)).toBe(false);
             })
@@ -327,7 +326,6 @@ describe("ConsentService interface", () => {
                 };
                 const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
-                expect(consentService.hasConsent('')).toBe(true);
                 expect(consentService.hasConsent(undefined)).toBe(true);
                 expect(consentService.hasConsent(null)).toBe(true);
             })

--- a/src/lib/domain/_tests/consent.test.ts
+++ b/src/lib/domain/_tests/consent.test.ts
@@ -3,43 +3,43 @@ import {ConsentServiceImpl, ConsentCategoryPreferences, ConsentPreference, resol
 describe("resolveConsentMode function", () => {
     describe("workspace consent mode", () => {
         it("Should return workspace consent mode when provided, regardless of country", () => {
-            expect(resolveConsentMode('US', 'STRICT')).toBe('STRICT');
-            expect(resolveConsentMode('FR', 'RELAXED')).toBe('RELAXED');
+            expect(resolveConsentMode('US', 'strict')).toBe('strict');
+            expect(resolveConsentMode('FR', 'relaxed')).toBe('relaxed');
         })
 
         it("Should return workspace consent mode when country is undefined", () => {
-            expect(resolveConsentMode(undefined, 'STRICT')).toBe('STRICT');
-            expect(resolveConsentMode(undefined, 'RELAXED')).toBe('RELAXED');
+            expect(resolveConsentMode(undefined, 'strict')).toBe('strict');
+            expect(resolveConsentMode(undefined, 'relaxed')).toBe('relaxed');
         })
     })
 
     describe("country-based fallback", () => {
-        it("Should return 'STRICT' for GDPR countries", () => {
-            expect(resolveConsentMode('FR')).toBe('STRICT');
-            expect(resolveConsentMode('DE')).toBe('STRICT');
-            expect(resolveConsentMode('GB')).toBe('STRICT');
+        it("Should return 'strict' for GDPR countries", () => {
+            expect(resolveConsentMode('FR')).toBe('strict');
+            expect(resolveConsentMode('DE')).toBe('strict');
+            expect(resolveConsentMode('GB')).toBe('strict');
         })
 
-        it("Should return 'RELAXED' for non-GDPR countries", () => {
-            expect(resolveConsentMode('US')).toBe('RELAXED');
-            expect(resolveConsentMode('SA')).toBe('RELAXED');
+        it("Should return 'relaxed' for non-GDPR countries", () => {
+            expect(resolveConsentMode('US')).toBe('relaxed');
+            expect(resolveConsentMode('SA')).toBe('relaxed');
         })
 
-        it("Should return 'RELAXED' for empty or undefined country", () => {
-            expect(resolveConsentMode('')).toBe('RELAXED');
-            expect(resolveConsentMode(undefined)).toBe('RELAXED');
+        it("Should return 'relaxed' for empty or undefined country", () => {
+            expect(resolveConsentMode('')).toBe('relaxed');
+            expect(resolveConsentMode(undefined)).toBe('relaxed');
         })
 
         it("Should normalize lowercase country codes", () => {
-            expect(resolveConsentMode('fr')).toBe('STRICT');
-            expect(resolveConsentMode('de')).toBe('STRICT');
-            expect(resolveConsentMode('us')).toBe('RELAXED');
+            expect(resolveConsentMode('fr')).toBe('strict');
+            expect(resolveConsentMode('de')).toBe('strict');
+            expect(resolveConsentMode('us')).toBe('relaxed');
         })
 
         it("Should trim whitespace from country codes", () => {
-            expect(resolveConsentMode(' FR ')).toBe('STRICT');
-            expect(resolveConsentMode('  DE')).toBe('STRICT');
-            expect(resolveConsentMode('US  ')).toBe('RELAXED');
+            expect(resolveConsentMode(' FR ')).toBe('strict');
+            expect(resolveConsentMode('  DE')).toBe('strict');
+            expect(resolveConsentMode('US  ')).toBe('relaxed');
         })
     })
 })
@@ -48,7 +48,7 @@ describe("ConsentServiceImpl class", () => {
     describe("constructor", () => {
         describe("initial consent", () => {
             it("Should initialize with all UNSPECIFIED when no initialConsent provided", () => {
-                const consentService = new ConsentServiceImpl('RELAXED');
+                const consentService = new ConsentServiceImpl('relaxed');
 
                 const consent = consentService.getConsent();
 
@@ -70,7 +70,7 @@ describe("ConsentServiceImpl class", () => {
                     marketing: ConsentPreference.UNSPECIFIED,
                     personalization: ConsentPreference.UNSPECIFIED,
                 };
-                const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
+                const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
                 expect(consentService.getConsent().categoryPreferences).toEqual({
                     advertising: ConsentPreference.DENIED,
@@ -89,7 +89,7 @@ describe("ConsentServiceImpl class", () => {
                     marketing: ConsentPreference.UNSPECIFIED,
                     personalization: ConsentPreference.UNSPECIFIED,
                 };
-                const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
+                const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
                 consentService.updateConsent({
                     advertising: ConsentPreference.UNSPECIFIED,
@@ -114,7 +114,7 @@ describe("ConsentServiceImpl class", () => {
                 marketing: ConsentPreference.UNSPECIFIED,
                 personalization: ConsentPreference.UNSPECIFIED,
             };
-            const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
+            const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
             consentService.updateConsent({
                 advertising: ConsentPreference.GRANTED,
@@ -136,7 +136,7 @@ describe("ConsentServiceImpl class", () => {
                 marketing: ConsentPreference.UNSPECIFIED,
                 personalization: ConsentPreference.UNSPECIFIED,
             };
-            const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
+            const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
             // TypeScript would catch this, but testing runtime behavior
             consentService.updateConsent({ invalid_category: ConsentPreference.GRANTED } as unknown as ConsentCategoryPreferences);
@@ -154,7 +154,7 @@ describe("ConsentServiceImpl class", () => {
     describe("hasConsent method", () => {
         describe("strict mode", () => {
             it("Should return false when no categories configured", () => {
-                const consentService = new ConsentServiceImpl('STRICT');
+                const consentService = new ConsentServiceImpl('strict');
 
                 expect(consentService.hasConsent('ANALYTICS')).toBe(false);
             })
@@ -167,7 +167,7 @@ describe("ConsentServiceImpl class", () => {
                     marketing: ConsentPreference.UNSPECIFIED,
                     personalization: ConsentPreference.UNSPECIFIED,
                 };
-                const consentService = new ConsentServiceImpl('STRICT', initialConsent);
+                const consentService = new ConsentServiceImpl('strict', initialConsent);
 
                 expect(consentService.hasConsent('ANALYTICS')).toBe(false);
             })
@@ -181,7 +181,7 @@ describe("ConsentServiceImpl class", () => {
                     marketing: ConsentPreference.UNSPECIFIED,
                     personalization: ConsentPreference.UNSPECIFIED,
                 };
-                const consentService = new ConsentServiceImpl('STRICT', initialConsent);
+                const consentService = new ConsentServiceImpl('strict', initialConsent);
 
                 expect(consentService.hasConsent('ANALYTICS')).toBe(true);
             })
@@ -194,7 +194,7 @@ describe("ConsentServiceImpl class", () => {
                     marketing: ConsentPreference.UNSPECIFIED,
                     personalization: ConsentPreference.UNSPECIFIED,
                 };
-                const consentService = new ConsentServiceImpl('STRICT', initialConsent);
+                const consentService = new ConsentServiceImpl('strict', initialConsent);
 
                 expect(consentService.hasConsent('ANALYTICS')).toBe(false);
             })
@@ -202,7 +202,7 @@ describe("ConsentServiceImpl class", () => {
 
         describe("relaxed mode", () => {
             it("Should return true when no categories configured", () => {
-                const consentService = new ConsentServiceImpl('RELAXED');
+                const consentService = new ConsentServiceImpl('relaxed');
 
                 expect(consentService.hasConsent('ANALYTICS')).toBe(true);
             })
@@ -215,7 +215,7 @@ describe("ConsentServiceImpl class", () => {
                     marketing: ConsentPreference.UNSPECIFIED,
                     personalization: ConsentPreference.UNSPECIFIED,
                 };
-                const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
+                const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
                 expect(consentService.hasConsent('ANALYTICS')).toBe(true);
             })
@@ -229,7 +229,7 @@ describe("ConsentServiceImpl class", () => {
                     marketing: ConsentPreference.UNSPECIFIED,
                     personalization: ConsentPreference.UNSPECIFIED,
                 };
-                const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
+                const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
                 expect(consentService.hasConsent('ANALYTICS')).toBe(true);
             })
@@ -242,7 +242,7 @@ describe("ConsentServiceImpl class", () => {
                     marketing: ConsentPreference.UNSPECIFIED,
                     personalization: ConsentPreference.UNSPECIFIED,
                 };
-                const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
+                const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
                 expect(consentService.hasConsent('ANALYTICS')).toBe(false);
             })
@@ -258,7 +258,7 @@ describe("ConsentServiceImpl class", () => {
                 marketing: ConsentPreference.UNSPECIFIED,
                 personalization: ConsentPreference.UNSPECIFIED,
             };
-            const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
+            const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
             expect(consentService.getConsent()).toEqual({
                 categoryPreferences: {
@@ -279,7 +279,7 @@ describe("ConsentServiceImpl class", () => {
                 marketing: ConsentPreference.UNSPECIFIED,
                 personalization: ConsentPreference.UNSPECIFIED,
             };
-            const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
+            const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
             consentService.updateConsent({
                 advertising: ConsentPreference.UNSPECIFIED,

--- a/src/lib/domain/_tests/consent.test.ts
+++ b/src/lib/domain/_tests/consent.test.ts
@@ -222,7 +222,7 @@ describe("ConsentService interface", () => {
             const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
             // TypeScript would catch this, but testing runtime behavior
-            consentService.updateConsent({ invalid_category: ConsentPreference.GRANTED } as unknown as ConsentCategoryPreferences);
+            consentService.updateConsent({ invalid_category: ConsentPreference.GRANTED } as unknown as Partial<ConsentCategoryPreferences>);
 
             expect(consentService.getConsent().categoryPreferences).toEqual({
                 advertising: ConsentPreference.UNSPECIFIED,

--- a/src/lib/domain/_tests/consent.test.ts
+++ b/src/lib/domain/_tests/consent.test.ts
@@ -1,46 +1,71 @@
-import {ConsentServiceImpl, ConsentCategoryPreferences, ConsentPreference, resolveConsentMode} from "../consent";
+import {ConsentServiceImpl, ConsentCategoryPreferences, ConsentPreference, resolveConsentMode, normalizeConsentCategory} from "../consent";
 
 describe("resolveConsentMode function", () => {
     describe("workspace consent mode", () => {
         it("Should return workspaceConsentMode when provided, regardless of country", () => {
-            expect(resolveConsentMode('US', 'strict')).toBe('strict');
-            expect(resolveConsentMode('FR', 'relaxed')).toBe('relaxed');
+            expect(resolveConsentMode('US', 'STRICT')).toBe('STRICT');
+            expect(resolveConsentMode('FR', 'RELAXED')).toBe('RELAXED');
         })
 
         it("Should return workspaceConsentMode when country is undefined", () => {
-            expect(resolveConsentMode(undefined, 'strict')).toBe('strict');
-            expect(resolveConsentMode(undefined, 'relaxed')).toBe('relaxed');
+            expect(resolveConsentMode(undefined, 'STRICT')).toBe('STRICT');
+            expect(resolveConsentMode(undefined, 'RELAXED')).toBe('RELAXED');
         })
     })
 
     describe("country-based fallback", () => {
-        it("Should return 'strict' for GDPR countries", () => {
-            expect(resolveConsentMode('FR')).toBe('strict');
-            expect(resolveConsentMode('DE')).toBe('strict');
-            expect(resolveConsentMode('GB')).toBe('strict');
+        it("Should return 'STRICT' for GDPR countries", () => {
+            expect(resolveConsentMode('FR')).toBe('STRICT');
+            expect(resolveConsentMode('DE')).toBe('STRICT');
+            expect(resolveConsentMode('GB')).toBe('STRICT');
         })
 
-        it("Should return 'relaxed' for non-GDPR countries", () => {
-            expect(resolveConsentMode('US')).toBe('relaxed');
-            expect(resolveConsentMode('SA')).toBe('relaxed');
+        it("Should return 'RELAXED' for non-GDPR countries", () => {
+            expect(resolveConsentMode('US')).toBe('RELAXED');
+            expect(resolveConsentMode('SA')).toBe('RELAXED');
         })
 
-        it("Should return 'relaxed' for empty or undefined country", () => {
-            expect(resolveConsentMode('')).toBe('relaxed');
-            expect(resolveConsentMode(undefined)).toBe('relaxed');
+        it("Should return 'RELAXED' for empty or undefined country", () => {
+            expect(resolveConsentMode('')).toBe('RELAXED');
+            expect(resolveConsentMode(undefined)).toBe('RELAXED');
         })
 
         it("Should normalize lowercase country codes", () => {
-            expect(resolveConsentMode('fr')).toBe('strict');
-            expect(resolveConsentMode('de')).toBe('strict');
-            expect(resolveConsentMode('us')).toBe('relaxed');
+            expect(resolveConsentMode('fr')).toBe('STRICT');
+            expect(resolveConsentMode('de')).toBe('STRICT');
+            expect(resolveConsentMode('us')).toBe('RELAXED');
         })
 
         it("Should trim whitespace from country codes", () => {
-            expect(resolveConsentMode(' FR ')).toBe('strict');
-            expect(resolveConsentMode('  DE')).toBe('strict');
-            expect(resolveConsentMode('US  ')).toBe('relaxed');
+            expect(resolveConsentMode(' FR ')).toBe('STRICT');
+            expect(resolveConsentMode('  DE')).toBe('STRICT');
+            expect(resolveConsentMode('US  ')).toBe('RELAXED');
         })
+    })
+})
+
+describe("normalizeConsentCategory function", () => {
+    it("Should normalize uppercase category to lowercase", () => {
+        expect(normalizeConsentCategory('ADVERTISING')).toBe('advertising');
+        expect(normalizeConsentCategory('ANALYTICS')).toBe('analytics');
+        expect(normalizeConsentCategory('FUNCTIONAL')).toBe('functional');
+        expect(normalizeConsentCategory('MARKETING')).toBe('marketing');
+        expect(normalizeConsentCategory('PERSONALIZATION')).toBe('personalization');
+    })
+
+    it("Should accept already lowercase category", () => {
+        expect(normalizeConsentCategory('advertising')).toBe('advertising');
+        expect(normalizeConsentCategory('analytics')).toBe('analytics');
+    })
+
+    it("Should trim whitespace", () => {
+        expect(normalizeConsentCategory(' ADVERTISING ')).toBe('advertising');
+    })
+
+    it("Should return undefined for unrecognized values", () => {
+        expect(normalizeConsentCategory('unknown')).toBeUndefined();
+        expect(normalizeConsentCategory('')).toBeUndefined();
+        expect(normalizeConsentCategory(undefined)).toBeUndefined();
     })
 })
 
@@ -48,7 +73,7 @@ describe("ConsentServiceImpl class", () => {
     describe("constructor", () => {
         describe("initial consent", () => {
             it("Should initialize with all UNSPECIFIED when no initialConsent provided", () => {
-                const consentService = new ConsentServiceImpl('relaxed');
+                const consentService = new ConsentServiceImpl('RELAXED');
 
                 const consent = consentService.getConsent();
 
@@ -70,7 +95,7 @@ describe("ConsentServiceImpl class", () => {
                     marketing: ConsentPreference.UNSPECIFIED,
                     personalization: ConsentPreference.UNSPECIFIED,
                 };
-                const consentService = new ConsentServiceImpl('relaxed', initialConsent);
+                const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
 
                 const consent = consentService.getConsent();
 
@@ -92,7 +117,7 @@ describe("ConsentServiceImpl class", () => {
                     marketing: ConsentPreference.DENIED,
                     personalization: ConsentPreference.GRANTED,
                 };
-                const consentService = new ConsentServiceImpl('relaxed', initialConsent);
+                const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
 
                 const consent = consentService.getConsent();
 
@@ -113,7 +138,7 @@ describe("ConsentServiceImpl class", () => {
                     marketing: ConsentPreference.UNSPECIFIED,
                     personalization: ConsentPreference.UNSPECIFIED,
                 };
-                const consentService = new ConsentServiceImpl('relaxed', initialConsent);
+                const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
 
                 consentService.updateConsent({
                     advertising: ConsentPreference.UNSPECIFIED,
@@ -140,7 +165,7 @@ describe("ConsentService interface", () => {
                 marketing: ConsentPreference.UNSPECIFIED,
                 personalization: ConsentPreference.UNSPECIFIED,
             };
-            const consentService = new ConsentServiceImpl('relaxed', initialConsent);
+            const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
 
             expect(consentService.getConsent().categoryPreferences.advertising).toBe(ConsentPreference.DENIED);
             expect(consentService.getConsent().categoryPreferences.analytics).toBe(ConsentPreference.DENIED);
@@ -165,7 +190,7 @@ describe("ConsentService interface", () => {
                 marketing: ConsentPreference.UNSPECIFIED,
                 personalization: ConsentPreference.UNSPECIFIED,
             };
-            const consentService = new ConsentServiceImpl('relaxed', initialConsent);
+            const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
 
             consentService.updateConsent({
                 advertising: ConsentPreference.GRANTED,
@@ -192,7 +217,7 @@ describe("ConsentService interface", () => {
                 marketing: ConsentPreference.DENIED,
                 personalization: ConsentPreference.UNSPECIFIED,
             };
-            const consentService = new ConsentServiceImpl('relaxed', initialConsent);
+            const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
 
             consentService.updateConsent({
                 advertising: ConsentPreference.GRANTED,
@@ -219,7 +244,7 @@ describe("ConsentService interface", () => {
                 marketing: ConsentPreference.UNSPECIFIED,
                 personalization: ConsentPreference.UNSPECIFIED,
             };
-            const consentService = new ConsentServiceImpl('relaxed', initialConsent);
+            const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
 
             // TypeScript would catch this, but testing runtime behavior
             consentService.updateConsent({ invalid_category: ConsentPreference.GRANTED } as unknown as Partial<ConsentCategoryPreferences>);
@@ -237,7 +262,7 @@ describe("ConsentService interface", () => {
     describe("hasConsent method", () => {
         describe("strict mode", () => {
             it("Should return false when no categories configured", () => {
-                const consentService = new ConsentServiceImpl('strict');
+                const consentService = new ConsentServiceImpl('STRICT');
 
                 expect(consentService.hasConsent('analytics')).toBe(false);
             })
@@ -250,13 +275,13 @@ describe("ConsentService interface", () => {
                     marketing: ConsentPreference.UNSPECIFIED,
                     personalization: ConsentPreference.UNSPECIFIED,
                 };
-                const consentService = new ConsentServiceImpl('strict', initialConsent);
+                const consentService = new ConsentServiceImpl('STRICT', initialConsent);
 
                 expect(consentService.hasConsent('analytics')).toBe(false);
             })
 
             it("Should return false when destination category is null or undefined", () => {
-                const consentService = new ConsentServiceImpl('strict');
+                const consentService = new ConsentServiceImpl('STRICT');
 
                 expect(consentService.hasConsent(undefined)).toBe(false);
                 expect(consentService.hasConsent(null)).toBe(false);
@@ -270,7 +295,7 @@ describe("ConsentService interface", () => {
                     marketing: ConsentPreference.UNSPECIFIED,
                     personalization: ConsentPreference.UNSPECIFIED,
                 };
-                const consentService = new ConsentServiceImpl('strict', initialConsent);
+                const consentService = new ConsentServiceImpl('STRICT', initialConsent);
 
                 expect(consentService.hasConsent('analytics')).toBe(true);
             })
@@ -283,7 +308,7 @@ describe("ConsentService interface", () => {
                     marketing: ConsentPreference.UNSPECIFIED,
                     personalization: ConsentPreference.UNSPECIFIED,
                 };
-                const consentService = new ConsentServiceImpl('strict', initialConsent);
+                const consentService = new ConsentServiceImpl('STRICT', initialConsent);
 
                 expect(consentService.hasConsent('analytics')).toBe(false);
             })
@@ -291,7 +316,7 @@ describe("ConsentService interface", () => {
 
         describe("relaxed mode", () => {
             it("Should return true when no categories configured", () => {
-                const consentService = new ConsentServiceImpl('relaxed');
+                const consentService = new ConsentServiceImpl('RELAXED');
 
                 expect(consentService.hasConsent('analytics')).toBe(true);
             })
@@ -304,13 +329,13 @@ describe("ConsentService interface", () => {
                     marketing: ConsentPreference.UNSPECIFIED,
                     personalization: ConsentPreference.UNSPECIFIED,
                 };
-                const consentService = new ConsentServiceImpl('relaxed', initialConsent);
+                const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
 
                 expect(consentService.hasConsent('analytics')).toBe(true);
             })
 
             it("Should return true when destination category is null or undefined", () => {
-                const consentService = new ConsentServiceImpl('relaxed');
+                const consentService = new ConsentServiceImpl('RELAXED');
 
                 expect(consentService.hasConsent(undefined)).toBe(true);
                 expect(consentService.hasConsent(null)).toBe(true);
@@ -324,7 +349,7 @@ describe("ConsentService interface", () => {
                     marketing: ConsentPreference.UNSPECIFIED,
                     personalization: ConsentPreference.UNSPECIFIED,
                 };
-                const consentService = new ConsentServiceImpl('relaxed', initialConsent);
+                const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
 
                 expect(consentService.hasConsent('analytics')).toBe(true);
             })
@@ -337,7 +362,7 @@ describe("ConsentService interface", () => {
                     marketing: ConsentPreference.UNSPECIFIED,
                     personalization: ConsentPreference.UNSPECIFIED,
                 };
-                const consentService = new ConsentServiceImpl('relaxed', initialConsent);
+                const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
 
                 expect(consentService.hasConsent('analytics')).toBe(false);
             })
@@ -353,7 +378,7 @@ describe("ConsentService interface", () => {
                 marketing: ConsentPreference.UNSPECIFIED,
                 personalization: ConsentPreference.UNSPECIFIED,
             };
-            const consentService = new ConsentServiceImpl('relaxed', initialConsent);
+            const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
 
             const consent = consentService.getConsent();
 
@@ -376,7 +401,7 @@ describe("ConsentService interface", () => {
                 marketing: ConsentPreference.UNSPECIFIED,
                 personalization: ConsentPreference.UNSPECIFIED,
             };
-            const consentService = new ConsentServiceImpl('relaxed', initialConsent);
+            const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
 
             expect(consentService.getConsent().categoryPreferences.analytics).toBe(ConsentPreference.DENIED);
 

--- a/src/lib/domain/_tests/consent.test.ts
+++ b/src/lib/domain/_tests/consent.test.ts
@@ -1,13 +1,13 @@
-import {ConsentServiceImpl, ConsentCategoryPreferences, ConsentPreference, resolveConsentMode, normalizeConsentCategory} from "../consent";
+import {ConsentServiceImpl, ConsentCategoryPreferences, ConsentPreference, resolveConsentMode} from "../consent";
 
 describe("resolveConsentMode function", () => {
     describe("workspace consent mode", () => {
-        it("Should return workspaceConsentMode when provided, regardless of country", () => {
+        it("Should return workspace consent mode when provided, regardless of country", () => {
             expect(resolveConsentMode('US', 'STRICT')).toBe('STRICT');
             expect(resolveConsentMode('FR', 'RELAXED')).toBe('RELAXED');
         })
 
-        it("Should return workspaceConsentMode when country is undefined", () => {
+        it("Should return workspace consent mode when country is undefined", () => {
             expect(resolveConsentMode(undefined, 'STRICT')).toBe('STRICT');
             expect(resolveConsentMode(undefined, 'RELAXED')).toBe('RELAXED');
         })
@@ -44,31 +44,6 @@ describe("resolveConsentMode function", () => {
     })
 })
 
-describe("normalizeConsentCategory function", () => {
-    it("Should normalize uppercase category to lowercase", () => {
-        expect(normalizeConsentCategory('ADVERTISING')).toBe('advertising');
-        expect(normalizeConsentCategory('ANALYTICS')).toBe('analytics');
-        expect(normalizeConsentCategory('FUNCTIONAL')).toBe('functional');
-        expect(normalizeConsentCategory('MARKETING')).toBe('marketing');
-        expect(normalizeConsentCategory('PERSONALIZATION')).toBe('personalization');
-    })
-
-    it("Should accept already lowercase category", () => {
-        expect(normalizeConsentCategory('advertising')).toBe('advertising');
-        expect(normalizeConsentCategory('analytics')).toBe('analytics');
-    })
-
-    it("Should trim whitespace", () => {
-        expect(normalizeConsentCategory(' ADVERTISING ')).toBe('advertising');
-    })
-
-    it("Should return undefined for unrecognized values", () => {
-        expect(normalizeConsentCategory('unknown')).toBeUndefined();
-        expect(normalizeConsentCategory('')).toBeUndefined();
-        expect(normalizeConsentCategory(undefined)).toBeUndefined();
-    })
-})
-
 describe("ConsentServiceImpl class", () => {
     describe("constructor", () => {
         describe("initial consent", () => {
@@ -97,36 +72,12 @@ describe("ConsentServiceImpl class", () => {
                 };
                 const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
 
-                const consent = consentService.getConsent();
-
-                expect(consent).toBeDefined();
-                expect(consent.categoryPreferences).toEqual({
+                expect(consentService.getConsent().categoryPreferences).toEqual({
                     advertising: ConsentPreference.DENIED,
                     analytics: ConsentPreference.GRANTED,
                     functional: ConsentPreference.UNSPECIFIED,
                     marketing: ConsentPreference.UNSPECIFIED,
                     personalization: ConsentPreference.UNSPECIFIED,
-                });
-            })
-
-            it("Should apply all standard category types", () => {
-                const initialConsent: ConsentCategoryPreferences = {
-                    advertising: ConsentPreference.GRANTED,
-                    analytics: ConsentPreference.GRANTED,
-                    functional: ConsentPreference.GRANTED,
-                    marketing: ConsentPreference.DENIED,
-                    personalization: ConsentPreference.GRANTED,
-                };
-                const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
-
-                const consent = consentService.getConsent();
-
-                expect(consent.categoryPreferences).toEqual({
-                    advertising: ConsentPreference.GRANTED,
-                    analytics: ConsentPreference.GRANTED,
-                    functional: ConsentPreference.GRANTED,
-                    marketing: ConsentPreference.DENIED,
-                    personalization: ConsentPreference.GRANTED,
                 });
             })
 
@@ -153,9 +104,7 @@ describe("ConsentServiceImpl class", () => {
             })
         })
     })
-})
 
-describe("ConsentService interface", () => {
     describe("updateConsent method", () => {
         it("Should update consent values for standard categories", () => {
             const initialConsent: ConsentCategoryPreferences = {
@@ -166,9 +115,6 @@ describe("ConsentService interface", () => {
                 personalization: ConsentPreference.UNSPECIFIED,
             };
             const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
-
-            expect(consentService.getConsent().categoryPreferences.advertising).toBe(ConsentPreference.DENIED);
-            expect(consentService.getConsent().categoryPreferences.analytics).toBe(ConsentPreference.DENIED);
 
             consentService.updateConsent({
                 advertising: ConsentPreference.GRANTED,
@@ -182,60 +128,6 @@ describe("ConsentService interface", () => {
             expect(consentService.getConsent().categoryPreferences.analytics).toBe(ConsentPreference.DENIED);
         })
 
-        it("Should update categories from UNSPECIFIED to explicit values", () => {
-            const initialConsent: ConsentCategoryPreferences = {
-                advertising: ConsentPreference.UNSPECIFIED,
-                analytics: ConsentPreference.GRANTED,
-                functional: ConsentPreference.UNSPECIFIED,
-                marketing: ConsentPreference.UNSPECIFIED,
-                personalization: ConsentPreference.UNSPECIFIED,
-            };
-            const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
-
-            consentService.updateConsent({
-                advertising: ConsentPreference.GRANTED,
-                analytics: ConsentPreference.GRANTED,
-                functional: ConsentPreference.UNSPECIFIED,
-                marketing: ConsentPreference.DENIED,
-                personalization: ConsentPreference.UNSPECIFIED,
-            });
-
-            expect(consentService.getConsent().categoryPreferences).toEqual({
-                advertising: ConsentPreference.GRANTED,
-                analytics: ConsentPreference.GRANTED,
-                functional: ConsentPreference.UNSPECIFIED,
-                marketing: ConsentPreference.DENIED,
-                personalization: ConsentPreference.UNSPECIFIED,
-            });
-        })
-
-        it("Should update multiple categories at once", () => {
-            const initialConsent: ConsentCategoryPreferences = {
-                advertising: ConsentPreference.DENIED,
-                analytics: ConsentPreference.DENIED,
-                functional: ConsentPreference.UNSPECIFIED,
-                marketing: ConsentPreference.DENIED,
-                personalization: ConsentPreference.UNSPECIFIED,
-            };
-            const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
-
-            consentService.updateConsent({
-                advertising: ConsentPreference.GRANTED,
-                analytics: ConsentPreference.GRANTED,
-                functional: ConsentPreference.UNSPECIFIED,
-                marketing: ConsentPreference.DENIED,
-                personalization: ConsentPreference.UNSPECIFIED,
-            });
-
-            expect(consentService.getConsent().categoryPreferences).toEqual({
-                advertising: ConsentPreference.GRANTED,
-                analytics: ConsentPreference.GRANTED,
-                functional: ConsentPreference.UNSPECIFIED,
-                marketing: ConsentPreference.DENIED,
-                personalization: ConsentPreference.UNSPECIFIED,
-            });
-        })
-
         it("Should ignore invalid category names", () => {
             const initialConsent: ConsentCategoryPreferences = {
                 advertising: ConsentPreference.UNSPECIFIED,
@@ -247,7 +139,7 @@ describe("ConsentService interface", () => {
             const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
 
             // TypeScript would catch this, but testing runtime behavior
-            consentService.updateConsent({ invalid_category: ConsentPreference.GRANTED } as unknown as Partial<ConsentCategoryPreferences>);
+            consentService.updateConsent({ invalid_category: ConsentPreference.GRANTED } as unknown as ConsentCategoryPreferences);
 
             expect(consentService.getConsent().categoryPreferences).toEqual({
                 advertising: ConsentPreference.UNSPECIFIED,
@@ -264,7 +156,7 @@ describe("ConsentService interface", () => {
             it("Should return false when no categories configured", () => {
                 const consentService = new ConsentServiceImpl('STRICT');
 
-                expect(consentService.hasConsent('analytics')).toBe(false);
+                expect(consentService.hasConsent('ANALYTICS')).toBe(false);
             })
 
             it("Should return false when category is UNSPECIFIED", () => {
@@ -277,15 +169,9 @@ describe("ConsentService interface", () => {
                 };
                 const consentService = new ConsentServiceImpl('STRICT', initialConsent);
 
-                expect(consentService.hasConsent('analytics')).toBe(false);
+                expect(consentService.hasConsent('ANALYTICS')).toBe(false);
             })
 
-            it("Should return false when destination category is null or undefined", () => {
-                const consentService = new ConsentServiceImpl('STRICT');
-
-                expect(consentService.hasConsent(undefined)).toBe(false);
-                expect(consentService.hasConsent(null)).toBe(false);
-            })
 
             it("Should return true when category is explicitly GRANTED", () => {
                 const initialConsent: ConsentCategoryPreferences = {
@@ -297,7 +183,7 @@ describe("ConsentService interface", () => {
                 };
                 const consentService = new ConsentServiceImpl('STRICT', initialConsent);
 
-                expect(consentService.hasConsent('analytics')).toBe(true);
+                expect(consentService.hasConsent('ANALYTICS')).toBe(true);
             })
 
             it("Should return false when category is explicitly DENIED", () => {
@@ -310,7 +196,7 @@ describe("ConsentService interface", () => {
                 };
                 const consentService = new ConsentServiceImpl('STRICT', initialConsent);
 
-                expect(consentService.hasConsent('analytics')).toBe(false);
+                expect(consentService.hasConsent('ANALYTICS')).toBe(false);
             })
         })
 
@@ -318,7 +204,7 @@ describe("ConsentService interface", () => {
             it("Should return true when no categories configured", () => {
                 const consentService = new ConsentServiceImpl('RELAXED');
 
-                expect(consentService.hasConsent('analytics')).toBe(true);
+                expect(consentService.hasConsent('ANALYTICS')).toBe(true);
             })
 
             it("Should return true when category is UNSPECIFIED", () => {
@@ -331,15 +217,9 @@ describe("ConsentService interface", () => {
                 };
                 const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
 
-                expect(consentService.hasConsent('analytics')).toBe(true);
+                expect(consentService.hasConsent('ANALYTICS')).toBe(true);
             })
 
-            it("Should return true when destination category is null or undefined", () => {
-                const consentService = new ConsentServiceImpl('RELAXED');
-
-                expect(consentService.hasConsent(undefined)).toBe(true);
-                expect(consentService.hasConsent(null)).toBe(true);
-            })
 
             it("Should return true when category is GRANTED", () => {
                 const initialConsent: ConsentCategoryPreferences = {
@@ -351,7 +231,7 @@ describe("ConsentService interface", () => {
                 };
                 const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
 
-                expect(consentService.hasConsent('analytics')).toBe(true);
+                expect(consentService.hasConsent('ANALYTICS')).toBe(true);
             })
 
             it("Should return false when category is explicitly DENIED", () => {
@@ -364,7 +244,7 @@ describe("ConsentService interface", () => {
                 };
                 const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
 
-                expect(consentService.hasConsent('analytics')).toBe(false);
+                expect(consentService.hasConsent('ANALYTICS')).toBe(false);
             })
         })
     })
@@ -380,9 +260,7 @@ describe("ConsentService interface", () => {
             };
             const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
 
-            const consent = consentService.getConsent();
-
-            expect(consent).toEqual({
+            expect(consentService.getConsent()).toEqual({
                 categoryPreferences: {
                     advertising: ConsentPreference.DENIED,
                     analytics: ConsentPreference.GRANTED,
@@ -402,8 +280,6 @@ describe("ConsentService interface", () => {
                 personalization: ConsentPreference.UNSPECIFIED,
             };
             const consentService = new ConsentServiceImpl('RELAXED', initialConsent);
-
-            expect(consentService.getConsent().categoryPreferences.analytics).toBe(ConsentPreference.DENIED);
 
             consentService.updateConsent({
                 advertising: ConsentPreference.UNSPECIFIED,

--- a/src/lib/domain/_tests/consent.test.ts
+++ b/src/lib/domain/_tests/consent.test.ts
@@ -1,59 +1,54 @@
-import {ConsentServiceImpl, ConsentCategoryPreferences, ConsentPreference} from "../consent";
+import {ConsentServiceImpl, ConsentCategoryPreferences, ConsentPreference, resolveConsentMode} from "../consent";
+
+describe("resolveConsentMode function", () => {
+    describe("workspace consent mode", () => {
+        it("Should return workspaceConsentMode when provided, regardless of country", () => {
+            expect(resolveConsentMode('US', 'strict')).toBe('strict');
+            expect(resolveConsentMode('FR', 'relaxed')).toBe('relaxed');
+        })
+
+        it("Should return workspaceConsentMode when country is undefined", () => {
+            expect(resolveConsentMode(undefined, 'strict')).toBe('strict');
+            expect(resolveConsentMode(undefined, 'relaxed')).toBe('relaxed');
+        })
+    })
+
+    describe("country-based fallback", () => {
+        it("Should return 'strict' for GDPR countries", () => {
+            expect(resolveConsentMode('FR')).toBe('strict');
+            expect(resolveConsentMode('DE')).toBe('strict');
+            expect(resolveConsentMode('GB')).toBe('strict');
+        })
+
+        it("Should return 'relaxed' for non-GDPR countries", () => {
+            expect(resolveConsentMode('US')).toBe('relaxed');
+            expect(resolveConsentMode('SA')).toBe('relaxed');
+        })
+
+        it("Should return 'relaxed' for empty or undefined country", () => {
+            expect(resolveConsentMode('')).toBe('relaxed');
+            expect(resolveConsentMode(undefined)).toBe('relaxed');
+        })
+
+        it("Should normalize lowercase country codes", () => {
+            expect(resolveConsentMode('fr')).toBe('strict');
+            expect(resolveConsentMode('de')).toBe('strict');
+            expect(resolveConsentMode('us')).toBe('relaxed');
+        })
+
+        it("Should trim whitespace from country codes", () => {
+            expect(resolveConsentMode(' FR ')).toBe('strict');
+            expect(resolveConsentMode('  DE')).toBe('strict');
+            expect(resolveConsentMode('US  ')).toBe('relaxed');
+        })
+    })
+})
 
 describe("ConsentServiceImpl class", () => {
     describe("constructor", () => {
-        describe("consent mode determination based on country", () => {
-            it.skip("Should use 'strict' mode for GDPR countries (e.g., 'DE', 'FR', 'GB')", () => {
-                const consentService = new ConsentServiceImpl('FR');
-
-                // In strict mode with no config, hasConsent should return false
-                expect(consentService.hasConsent('analytics')).toBe(false);
-            })
-
-            it("Should use 'relaxed' mode for non-GDPR countries (e.g., 'US', 'SA')", () => {
-                const consentService = new ConsentServiceImpl('SA');
-
-                // In relaxed mode with no config, hasConsent should return true
-                expect(consentService.hasConsent('analytics')).toBe(true);
-            })
-
-            it("Should use 'relaxed' mode for empty/undefined country", () => {
-                let consentService = new ConsentServiceImpl('');
-                expect(consentService.hasConsent('analytics')).toBe(true);
-
-                consentService = new ConsentServiceImpl(undefined);
-                expect(consentService.hasConsent('analytics')).toBe(true);
-            })
-
-            it.skip("Should normalize lowercase country codes", () => {
-                // GDPR countries in lowercase should still trigger strict mode
-                let consentService = new ConsentServiceImpl('fr');
-                expect(consentService.hasConsent('analytics')).toBe(false);
-
-                consentService = new ConsentServiceImpl('de');
-                expect(consentService.hasConsent('analytics')).toBe(false);
-
-                // Non-GDPR in lowercase should trigger relaxed mode
-                consentService = new ConsentServiceImpl('us');
-                expect(consentService.hasConsent('analytics')).toBe(true);
-            })
-
-            it.skip("Should trim whitespace from country codes", () => {
-                let consentService = new ConsentServiceImpl(' FR ');
-                expect(consentService.hasConsent('analytics')).toBe(false);
-
-                consentService = new ConsentServiceImpl('  DE');
-                expect(consentService.hasConsent('analytics')).toBe(false);
-
-                consentService = new ConsentServiceImpl('US  ');
-                expect(consentService.hasConsent('analytics')).toBe(true);
-            })
-
-        })
-
         describe("initial consent", () => {
             it("Should initialize with all UNSPECIFIED when no initialConsent provided", () => {
-                const consentService = new ConsentServiceImpl('US');
+                const consentService = new ConsentServiceImpl('relaxed');
 
                 const consent = consentService.getConsent();
 
@@ -75,7 +70,7 @@ describe("ConsentServiceImpl class", () => {
                     marketing: ConsentPreference.UNSPECIFIED,
                     personalization: ConsentPreference.UNSPECIFIED,
                 };
-                const consentService = new ConsentServiceImpl('FR', initialConsent);
+                const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
                 const consent = consentService.getConsent();
 
@@ -97,7 +92,7 @@ describe("ConsentServiceImpl class", () => {
                     marketing: ConsentPreference.DENIED,
                     personalization: ConsentPreference.GRANTED,
                 };
-                const consentService = new ConsentServiceImpl('FR', initialConsent);
+                const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
                 const consent = consentService.getConsent();
 
@@ -118,7 +113,7 @@ describe("ConsentServiceImpl class", () => {
                     marketing: ConsentPreference.UNSPECIFIED,
                     personalization: ConsentPreference.UNSPECIFIED,
                 };
-                const consentService = new ConsentServiceImpl('FR', initialConsent);
+                const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
                 consentService.updateConsent({
                     advertising: ConsentPreference.UNSPECIFIED,
@@ -145,7 +140,7 @@ describe("ConsentService interface", () => {
                 marketing: ConsentPreference.UNSPECIFIED,
                 personalization: ConsentPreference.UNSPECIFIED,
             };
-            const consentService = new ConsentServiceImpl('FR', initialConsent);
+            const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
             expect(consentService.getConsent().categoryPreferences.advertising).toBe(ConsentPreference.DENIED);
             expect(consentService.getConsent().categoryPreferences.analytics).toBe(ConsentPreference.DENIED);
@@ -170,7 +165,7 @@ describe("ConsentService interface", () => {
                 marketing: ConsentPreference.UNSPECIFIED,
                 personalization: ConsentPreference.UNSPECIFIED,
             };
-            const consentService = new ConsentServiceImpl('FR', initialConsent);
+            const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
             consentService.updateConsent({
                 advertising: ConsentPreference.GRANTED,
@@ -197,7 +192,7 @@ describe("ConsentService interface", () => {
                 marketing: ConsentPreference.DENIED,
                 personalization: ConsentPreference.UNSPECIFIED,
             };
-            const consentService = new ConsentServiceImpl('FR', initialConsent);
+            const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
             consentService.updateConsent({
                 advertising: ConsentPreference.GRANTED,
@@ -224,7 +219,7 @@ describe("ConsentService interface", () => {
                 marketing: ConsentPreference.UNSPECIFIED,
                 personalization: ConsentPreference.UNSPECIFIED,
             };
-            const consentService = new ConsentServiceImpl('FR', initialConsent);
+            const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
             // TypeScript would catch this, but testing runtime behavior
             consentService.updateConsent({ invalid_category: ConsentPreference.GRANTED } as unknown as ConsentCategoryPreferences);
@@ -240,153 +235,133 @@ describe("ConsentService interface", () => {
     })
 
     describe("hasConsent method", () => {
-        // Strict mode tests (GDPR country)
-        it.skip("Should return false in strict mode when no categories configured", () => {
-            const consentService = new ConsentServiceImpl('FR');
+        describe("strict mode", () => {
+            it("Should return false when no categories configured", () => {
+                const consentService = new ConsentServiceImpl('strict');
 
-            const result = consentService.hasConsent('analytics');
-            expect(result).toBe(false);
+                expect(consentService.hasConsent('analytics')).toBe(false);
+            })
+
+            it("Should return false when category is UNSPECIFIED", () => {
+                const initialConsent: ConsentCategoryPreferences = {
+                    advertising: ConsentPreference.GRANTED,
+                    analytics: ConsentPreference.UNSPECIFIED,
+                    functional: ConsentPreference.UNSPECIFIED,
+                    marketing: ConsentPreference.UNSPECIFIED,
+                    personalization: ConsentPreference.UNSPECIFIED,
+                };
+                const consentService = new ConsentServiceImpl('strict', initialConsent);
+
+                expect(consentService.hasConsent('analytics')).toBe(false);
+            })
+
+            it("Should return false when destination category is empty or undefined", () => {
+                const initialConsent: ConsentCategoryPreferences = {
+                    advertising: ConsentPreference.UNSPECIFIED,
+                    analytics: ConsentPreference.GRANTED,
+                    functional: ConsentPreference.UNSPECIFIED,
+                    marketing: ConsentPreference.UNSPECIFIED,
+                    personalization: ConsentPreference.UNSPECIFIED,
+                };
+                const consentService = new ConsentServiceImpl('strict', initialConsent);
+
+                expect(consentService.hasConsent('')).toBe(false);
+                expect(consentService.hasConsent(undefined)).toBe(false);
+                expect(consentService.hasConsent(null)).toBe(false);
+            })
+
+            it("Should return true when category is explicitly GRANTED", () => {
+                const initialConsent: ConsentCategoryPreferences = {
+                    advertising: ConsentPreference.UNSPECIFIED,
+                    analytics: ConsentPreference.GRANTED,
+                    functional: ConsentPreference.UNSPECIFIED,
+                    marketing: ConsentPreference.UNSPECIFIED,
+                    personalization: ConsentPreference.UNSPECIFIED,
+                };
+                const consentService = new ConsentServiceImpl('strict', initialConsent);
+
+                expect(consentService.hasConsent('analytics')).toBe(true);
+            })
+
+            it("Should return false when category is explicitly DENIED", () => {
+                const initialConsent: ConsentCategoryPreferences = {
+                    advertising: ConsentPreference.UNSPECIFIED,
+                    analytics: ConsentPreference.DENIED,
+                    functional: ConsentPreference.UNSPECIFIED,
+                    marketing: ConsentPreference.UNSPECIFIED,
+                    personalization: ConsentPreference.UNSPECIFIED,
+                };
+                const consentService = new ConsentServiceImpl('strict', initialConsent);
+
+                expect(consentService.hasConsent('analytics')).toBe(false);
+            })
         })
 
-        it.skip("Should return false in strict mode when category is UNSPECIFIED", () => {
-            const initialConsent: ConsentCategoryPreferences = {
-                advertising: ConsentPreference.GRANTED,
-                analytics: ConsentPreference.UNSPECIFIED,
-                functional: ConsentPreference.UNSPECIFIED,
-                marketing: ConsentPreference.UNSPECIFIED,
-                personalization: ConsentPreference.UNSPECIFIED,
-            };
-            const consentService = new ConsentServiceImpl('FR', initialConsent);
+        describe("relaxed mode", () => {
+            it("Should return true when no categories configured", () => {
+                const consentService = new ConsentServiceImpl('relaxed');
 
-            const result = consentService.hasConsent('analytics');
-            expect(result).toBe(false);
-        })
+                expect(consentService.hasConsent('analytics')).toBe(true);
+            })
 
-        it("Should return false when category is explicitly DENIED", () => {
-            const initialConsent: ConsentCategoryPreferences = {
-                advertising: ConsentPreference.UNSPECIFIED,
-                analytics: ConsentPreference.DENIED,
-                functional: ConsentPreference.UNSPECIFIED,
-                marketing: ConsentPreference.UNSPECIFIED,
-                personalization: ConsentPreference.UNSPECIFIED,
-            };
-            const consentService = new ConsentServiceImpl('FR', initialConsent);
+            it("Should return true when category is UNSPECIFIED", () => {
+                const initialConsent: ConsentCategoryPreferences = {
+                    advertising: ConsentPreference.GRANTED,
+                    analytics: ConsentPreference.UNSPECIFIED,
+                    functional: ConsentPreference.UNSPECIFIED,
+                    marketing: ConsentPreference.UNSPECIFIED,
+                    personalization: ConsentPreference.UNSPECIFIED,
+                };
+                const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
-            const result = consentService.hasConsent('analytics');
-            expect(result).toBe(false);
-        })
+                expect(consentService.hasConsent('analytics')).toBe(true);
+            })
 
-        it("Should return true when category is GRANTED", () => {
-            const initialConsent: ConsentCategoryPreferences = {
-                advertising: ConsentPreference.UNSPECIFIED,
-                analytics: ConsentPreference.GRANTED,
-                functional: ConsentPreference.UNSPECIFIED,
-                marketing: ConsentPreference.UNSPECIFIED,
-                personalization: ConsentPreference.UNSPECIFIED,
-            };
-            const consentService = new ConsentServiceImpl('FR', initialConsent);
+            it("Should return true when destination category is empty or undefined", () => {
+                const initialConsent: ConsentCategoryPreferences = {
+                    advertising: ConsentPreference.UNSPECIFIED,
+                    analytics: ConsentPreference.DENIED,
+                    functional: ConsentPreference.UNSPECIFIED,
+                    marketing: ConsentPreference.UNSPECIFIED,
+                    personalization: ConsentPreference.UNSPECIFIED,
+                };
+                const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
-            const result = consentService.hasConsent('analytics');
-            expect(result).toBe(true);
-        })
+                expect(consentService.hasConsent('')).toBe(true);
+                expect(consentService.hasConsent(undefined)).toBe(true);
+                expect(consentService.hasConsent(null)).toBe(true);
+            })
 
-        it.skip("Should return false in strict mode when category preference is UNSPECIFIED", () => {
-            const initialConsent: ConsentCategoryPreferences = {
-                advertising: ConsentPreference.UNSPECIFIED,
-                analytics: ConsentPreference.UNSPECIFIED,
-                functional: ConsentPreference.UNSPECIFIED,
-                marketing: ConsentPreference.UNSPECIFIED,
-                personalization: ConsentPreference.UNSPECIFIED,
-            };
-            const consentService = new ConsentServiceImpl('FR', initialConsent);
+            it("Should return true when category is GRANTED", () => {
+                const initialConsent: ConsentCategoryPreferences = {
+                    advertising: ConsentPreference.UNSPECIFIED,
+                    analytics: ConsentPreference.GRANTED,
+                    functional: ConsentPreference.UNSPECIFIED,
+                    marketing: ConsentPreference.UNSPECIFIED,
+                    personalization: ConsentPreference.UNSPECIFIED,
+                };
+                const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
-            const result = consentService.hasConsent('analytics');
-            expect(result).toBe(false);
-        })
+                expect(consentService.hasConsent('analytics')).toBe(true);
+            })
 
-        it("Should return true in relaxed mode when category preference is UNSPECIFIED", () => {
-            const initialConsent: ConsentCategoryPreferences = {
-                advertising: ConsentPreference.UNSPECIFIED,
-                analytics: ConsentPreference.UNSPECIFIED,
-                functional: ConsentPreference.UNSPECIFIED,
-                marketing: ConsentPreference.UNSPECIFIED,
-                personalization: ConsentPreference.UNSPECIFIED,
-            };
-            const consentService = new ConsentServiceImpl('US', initialConsent);
+            it("Should return false when category is explicitly DENIED", () => {
+                const initialConsent: ConsentCategoryPreferences = {
+                    advertising: ConsentPreference.UNSPECIFIED,
+                    analytics: ConsentPreference.DENIED,
+                    functional: ConsentPreference.UNSPECIFIED,
+                    marketing: ConsentPreference.UNSPECIFIED,
+                    personalization: ConsentPreference.UNSPECIFIED,
+                };
+                const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
-            const result = consentService.hasConsent('analytics');
-            expect(result).toBe(true);
-        })
-
-        it.skip("Should return false in strict mode when destination category is empty or undefined", () => {
-            const initialConsent: ConsentCategoryPreferences = {
-                advertising: ConsentPreference.UNSPECIFIED,
-                analytics: ConsentPreference.GRANTED,
-                functional: ConsentPreference.UNSPECIFIED,
-                marketing: ConsentPreference.UNSPECIFIED,
-                personalization: ConsentPreference.UNSPECIFIED,
-            };
-            const consentService = new ConsentServiceImpl('FR', initialConsent);
-
-            expect(consentService.hasConsent('')).toBe(false);
-            expect(consentService.hasConsent(undefined)).toBe(false);
-            expect(consentService.hasConsent(null)).toBe(false);
-        })
-
-        // Relaxed mode tests (non-GDPR country)
-        it("Should return true in relaxed mode when no categories configured", () => {
-            const consentService = new ConsentServiceImpl('US');
-
-            const result = consentService.hasConsent('analytics');
-            expect(result).toBe(true);
-        })
-
-        it("Should return true in relaxed mode when category is UNSPECIFIED", () => {
-            const initialConsent: ConsentCategoryPreferences = {
-                advertising: ConsentPreference.GRANTED,
-                analytics: ConsentPreference.UNSPECIFIED,
-                functional: ConsentPreference.UNSPECIFIED,
-                marketing: ConsentPreference.UNSPECIFIED,
-                personalization: ConsentPreference.UNSPECIFIED,
-            };
-            const consentService = new ConsentServiceImpl('US', initialConsent);
-
-            const result = consentService.hasConsent('analytics');
-            expect(result).toBe(true);
-        })
-
-        it("Should return false in relaxed mode when category is explicitly DENIED", () => {
-            const initialConsent: ConsentCategoryPreferences = {
-                advertising: ConsentPreference.UNSPECIFIED,
-                analytics: ConsentPreference.DENIED,
-                functional: ConsentPreference.UNSPECIFIED,
-                marketing: ConsentPreference.UNSPECIFIED,
-                personalization: ConsentPreference.UNSPECIFIED,
-            };
-            const consentService = new ConsentServiceImpl('US', initialConsent);
-
-            const result = consentService.hasConsent('analytics');
-            expect(result).toBe(false);
-        })
-
-        it("Should return true in relaxed mode when destination category is empty or undefined", () => {
-            const initialConsent: ConsentCategoryPreferences = {
-                advertising: ConsentPreference.UNSPECIFIED,
-                analytics: ConsentPreference.DENIED,
-                functional: ConsentPreference.UNSPECIFIED,
-                marketing: ConsentPreference.UNSPECIFIED,
-                personalization: ConsentPreference.UNSPECIFIED,
-            };
-            const consentService = new ConsentServiceImpl('US', initialConsent);
-
-            expect(consentService.hasConsent('')).toBe(true);
-            expect(consentService.hasConsent(undefined)).toBe(true);
-            expect(consentService.hasConsent(null)).toBe(true);
+                expect(consentService.hasConsent('analytics')).toBe(false);
+            })
         })
     })
 
     describe("getConsent method", () => {
-        it("Should return the current consent object with country", () => {
+        it("Should return the current consent object", () => {
             const initialConsent: ConsentCategoryPreferences = {
                 advertising: ConsentPreference.DENIED,
                 analytics: ConsentPreference.GRANTED,
@@ -394,7 +369,7 @@ describe("ConsentService interface", () => {
                 marketing: ConsentPreference.UNSPECIFIED,
                 personalization: ConsentPreference.UNSPECIFIED,
             };
-            const consentService = new ConsentServiceImpl('FR', initialConsent);
+            const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
             const consent = consentService.getConsent();
 
@@ -417,7 +392,7 @@ describe("ConsentService interface", () => {
                 marketing: ConsentPreference.UNSPECIFIED,
                 personalization: ConsentPreference.UNSPECIFIED,
             };
-            const consentService = new ConsentServiceImpl('FR', initialConsent);
+            const consentService = new ConsentServiceImpl('relaxed', initialConsent);
 
             expect(consentService.getConsent().categoryPreferences.analytics).toBe(ConsentPreference.DENIED);
 

--- a/src/lib/domain/consent.ts
+++ b/src/lib/domain/consent.ts
@@ -43,7 +43,7 @@ export type ConsentState = {
 
 export interface ConsentService {
     updateConsent(categoryPreferences: ConsentCategoryPreferences): void;
-    hasConsent(destinationCategory: string): boolean;
+    hasConsent(destinationCategory: ConsentCategory): boolean;
     getConsent(): Consent;
 }
 
@@ -56,9 +56,13 @@ const DEFAULT_CONSENT: ConsentCategoryPreferences = {
 };
 
 export function resolveConsentMode(country?: string, workspaceConsentMode?: ConsentMode): ConsentMode {
-    if (workspaceConsentMode) return workspaceConsentMode;
+    if (isConsentMode(workspaceConsentMode)) return workspaceConsentMode;
     const normalizedCountry = country?.trim().toUpperCase() || '';
     return GDPR_COUNTRIES.has(normalizedCountry) ? STRICT_MODE : RELAXED_MODE;
+}
+
+function isConsentMode(value?: string): value is ConsentMode {
+    return value === STRICT_MODE || value === RELAXED_MODE;
 }
 
 export class ConsentServiceImpl implements ConsentService {
@@ -89,7 +93,7 @@ export class ConsentServiceImpl implements ConsentService {
     }
 
     // Method that checks if consent is given for the specified category
-    public hasConsent(destinationCategory: string): boolean {
+    public hasConsent(destinationCategory: ConsentCategory): boolean {
         const consentMode = this.consentState.consentMode;
         const categoryPreferences = this.consentState.consent.categoryPreferences;
 

--- a/src/lib/domain/consent.ts
+++ b/src/lib/domain/consent.ts
@@ -1,5 +1,5 @@
-const STRICT_MODE = 'STRICT';
-const RELAXED_MODE = 'RELAXED';
+const STRICT_MODE = 'strict';
+const RELAXED_MODE = 'relaxed';
 
 // GDPR applies to EU member states plus EEA countries and UK
 const GDPR_COUNTRIES = new Set([

--- a/src/lib/domain/consent.ts
+++ b/src/lib/domain/consent.ts
@@ -17,7 +17,7 @@ const GDPR_COUNTRIES = new Set([
 
 export const CONSENT_CATEGORIES = ['ADVERTISING', 'ANALYTICS', 'FUNCTIONAL', 'MARKETING', 'PERSONALIZATION'] as const;
 
-export type ConsentCategory = Lowercase<typeof CONSENT_CATEGORIES[number]>;
+export type ConsentCategory = typeof CONSENT_CATEGORIES[number];
 
 export type ConsentMode = typeof STRICT_MODE | typeof RELAXED_MODE;
 
@@ -28,7 +28,7 @@ export enum ConsentPreference {
 }
 
 export type ConsentCategoryPreferences = {
-    [K in ConsentCategory]: ConsentPreference;
+    [K in Lowercase<ConsentCategory>]: ConsentPreference;
 };
 
 export type Consent = {
@@ -41,8 +41,8 @@ export type ConsentState = {
 }
 
 export interface ConsentService {
-    updateConsent(categoryPreferences: Partial<ConsentCategoryPreferences>): void;
-    hasConsent(destinationCategory: ConsentCategory | null | undefined): boolean;
+    updateConsent(categoryPreferences: ConsentCategoryPreferences): void;
+    hasConsent(destinationCategory: ConsentCategory): boolean;
     getConsent(): Consent;
 }
 
@@ -60,23 +60,17 @@ export function resolveConsentMode(country?: string, workspaceConsentMode?: Cons
     return GDPR_COUNTRIES.has(normalizedCountry) ? STRICT_MODE : RELAXED_MODE;
 }
 
-export function normalizeConsentCategory(value?: string): ConsentCategory | undefined {
-    const lower = value?.trim().toLowerCase();
-    return CONSENT_CATEGORIES.includes(lower?.toUpperCase() as typeof CONSENT_CATEGORIES[number])
-        ? lower as ConsentCategory
-        : undefined;
-}
-
-function isValidConsentMode(value?: string): value is ConsentMode {
+function isValidConsentMode(value?: ConsentMode): value is ConsentMode {
     return value === STRICT_MODE || value === RELAXED_MODE;
 }
+
 
 export class ConsentServiceImpl implements ConsentService {
     private readonly consentState: ConsentState;
 
     constructor(
         consentMode: ConsentMode,
-        initialConsent?: Partial<ConsentCategoryPreferences>
+        initialConsent?: ConsentCategoryPreferences
     ) {
         this.consentState = {
             consentMode,
@@ -86,11 +80,10 @@ export class ConsentServiceImpl implements ConsentService {
         };
     }
 
-    public updateConsent(categoryPreferences: Partial<ConsentCategoryPreferences>): void {
+    public updateConsent(categoryPreferences: ConsentCategoryPreferences): void {
         for (const [category, preference] of Object.entries(categoryPreferences)) {
-            const normalized = normalizeConsentCategory(category);
-            if (normalized) {
-                this.consentState.consent.categoryPreferences[normalized] = preference;
+            if (CONSENT_CATEGORIES.includes(category.toUpperCase() as ConsentCategory)) {
+                this.consentState.consent.categoryPreferences[category as Lowercase<ConsentCategory>] = preference;
             }
         }
     }
@@ -99,15 +92,13 @@ export class ConsentServiceImpl implements ConsentService {
         return this.consentState.consent;
     }
 
-    public hasConsent(destinationCategory: ConsentCategory | null | undefined): boolean {
+    public hasConsent(destinationCategory: ConsentCategory): boolean {
         const consentMode = this.consentState.consentMode;
         const categoryPreferences = this.consentState.consent.categoryPreferences;
 
-        if (!destinationCategory) {
-            return consentMode === RELAXED_MODE;
-        }
+        if (!destinationCategory) return consentMode === RELAXED_MODE;
 
-        const preference = categoryPreferences[destinationCategory];
+        const preference = categoryPreferences[destinationCategory.toLowerCase() as Lowercase<ConsentCategory>];
 
         if (preference === ConsentPreference.DENIED) return false;
         return preference === ConsentPreference.GRANTED || consentMode === RELAXED_MODE;

--- a/src/lib/domain/consent.ts
+++ b/src/lib/domain/consent.ts
@@ -43,7 +43,7 @@ export type ConsentState = {
 
 export interface ConsentService {
     updateConsent(categoryPreferences: ConsentCategoryPreferences): void;
-    hasConsent(destinationCategory: ConsentCategory): boolean;
+    hasConsent(destinationCategory: ConsentCategory | null | undefined): boolean;
     getConsent(): Consent;
 }
 

--- a/src/lib/domain/consent.ts
+++ b/src/lib/domain/consent.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const STRICT_MODE = 'strict';
 const RELAXED_MODE = 'relaxed';
 
@@ -19,6 +18,8 @@ const GDPR_COUNTRIES = new Set([
 
 export const CONSENT_CATEGORIES = ['advertising', 'analytics', 'functional', 'marketing', 'personalization'] as const;
 
+export type ConsentCategory = typeof CONSENT_CATEGORIES[number];
+
 export type ConsentMode = typeof STRICT_MODE | typeof RELAXED_MODE;
 
 export enum ConsentPreference {
@@ -28,7 +29,7 @@ export enum ConsentPreference {
 }
 
 export type ConsentCategoryPreferences = {
-    [K in typeof CONSENT_CATEGORIES[number]]: ConsentPreference;
+    [K in typeof CONSENT_CATEGORIES[number]]?: ConsentPreference;
 };
 
 export type Consent = {
@@ -54,28 +55,25 @@ const DEFAULT_CONSENT: ConsentCategoryPreferences = {
     personalization: ConsentPreference.UNSPECIFIED,
 };
 
+export function resolveConsentMode(country?: string, workspaceConsentMode?: ConsentMode): ConsentMode {
+    if (workspaceConsentMode) return workspaceConsentMode;
+    const normalizedCountry = country?.trim().toUpperCase() || '';
+    return GDPR_COUNTRIES.has(normalizedCountry) ? STRICT_MODE : RELAXED_MODE;
+}
+
 export class ConsentServiceImpl implements ConsentService {
     private readonly consentState: ConsentState;
 
     constructor(
-        country: string,
+        consentMode: ConsentMode,
         initialConsent?: ConsentCategoryPreferences
     ) {
-        const consentMode = this.getConsentMode(country);
         this.consentState = {
             consentMode,
             consent: {
-                categoryPreferences: initialConsent ? { ...initialConsent } : { ...DEFAULT_CONSENT },
+                categoryPreferences: { ...DEFAULT_CONSENT, ...initialConsent },
             }
         };
-    }
-
-    // Determine consent mode based on country
-    private getConsentMode(country?: string): ConsentMode {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const normalizedCountry = country?.trim().toUpperCase() || ''
-        //return GDPR_COUNTRIES.has(normalizedCountry) ? STRICT_MODE : RELAXED_MODE;
-        return RELAXED_MODE; // temporarily set every country to relaxed mode
     }
 
     public updateConsent(categoryPreferences: ConsentCategoryPreferences): void {
@@ -101,11 +99,10 @@ export class ConsentServiceImpl implements ConsentService {
 
         const preference = categoryPreferences[destinationCategory];
 
-        // If category has no explicit consent decision
-        if (preference === ConsentPreference.UNSPECIFIED) {
-            return consentMode === RELAXED_MODE; // Strict mode requires explicit consent, relaxed mode assumes consent
-        }
+        if (preference === ConsentPreference.GRANTED) return true;
+        if (preference === ConsentPreference.DENIED) return false;
 
-        return preference === ConsentPreference.GRANTED;
+        // Anything else (UNSPECIFIED or unrecognized value) falls back to mode
+        return consentMode === RELAXED_MODE;
     }
 }

--- a/src/lib/domain/consent.ts
+++ b/src/lib/domain/consent.ts
@@ -1,8 +1,7 @@
-const STRICT_MODE = 'strict';
-const RELAXED_MODE = 'relaxed';
+const STRICT_MODE = 'STRICT';
+const RELAXED_MODE = 'RELAXED';
 
 // GDPR applies to EU member states plus EEA countries and UK
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const GDPR_COUNTRIES = new Set([
     // EU Member States
     'AT', 'BE', 'BG', 'HR', 'CY', 'CZ', 'DK', 'EE', 'FI', 'FR',
@@ -16,9 +15,9 @@ const GDPR_COUNTRIES = new Set([
     'CH'
 ]);
 
-export const CONSENT_CATEGORIES = ['advertising', 'analytics', 'functional', 'marketing', 'personalization'] as const;
+export const CONSENT_CATEGORIES = ['ADVERTISING', 'ANALYTICS', 'FUNCTIONAL', 'MARKETING', 'PERSONALIZATION'] as const;
 
-export type ConsentCategory = typeof CONSENT_CATEGORIES[number];
+export type ConsentCategory = Lowercase<typeof CONSENT_CATEGORIES[number]>;
 
 export type ConsentMode = typeof STRICT_MODE | typeof RELAXED_MODE;
 
@@ -29,7 +28,7 @@ export enum ConsentPreference {
 }
 
 export type ConsentCategoryPreferences = {
-    [K in typeof CONSENT_CATEGORIES[number]]: ConsentPreference;
+    [K in ConsentCategory]: ConsentPreference;
 };
 
 export type Consent = {
@@ -61,6 +60,13 @@ export function resolveConsentMode(country?: string, workspaceConsentMode?: Cons
     return GDPR_COUNTRIES.has(normalizedCountry) ? STRICT_MODE : RELAXED_MODE;
 }
 
+export function normalizeConsentCategory(value?: string): ConsentCategory | undefined {
+    const lower = value?.trim().toLowerCase();
+    return CONSENT_CATEGORIES.includes(lower?.toUpperCase() as typeof CONSENT_CATEGORIES[number])
+        ? lower as ConsentCategory
+        : undefined;
+}
+
 function isValidConsentMode(value?: string): value is ConsentMode {
     return value === STRICT_MODE || value === RELAXED_MODE;
 }
@@ -82,8 +88,9 @@ export class ConsentServiceImpl implements ConsentService {
 
     public updateConsent(categoryPreferences: Partial<ConsentCategoryPreferences>): void {
         for (const [category, preference] of Object.entries(categoryPreferences)) {
-            if (CONSENT_CATEGORIES.includes(category as typeof CONSENT_CATEGORIES[number])) {
-                this.consentState.consent.categoryPreferences[category] = preference;
+            const normalized = normalizeConsentCategory(category);
+            if (normalized) {
+                this.consentState.consent.categoryPreferences[normalized] = preference;
             }
         }
     }
@@ -92,8 +99,7 @@ export class ConsentServiceImpl implements ConsentService {
         return this.consentState.consent;
     }
 
-    // Method that checks if consent is given for the specified category
-    public hasConsent(destinationCategory: ConsentCategory): boolean {
+    public hasConsent(destinationCategory: ConsentCategory | null | undefined): boolean {
         const consentMode = this.consentState.consentMode;
         const categoryPreferences = this.consentState.consent.categoryPreferences;
 

--- a/src/lib/domain/consent.ts
+++ b/src/lib/domain/consent.ts
@@ -56,12 +56,12 @@ const DEFAULT_CONSENT: ConsentCategoryPreferences = {
 };
 
 export function resolveConsentMode(country?: string, workspaceConsentMode?: ConsentMode): ConsentMode {
-    if (isConsentMode(workspaceConsentMode)) return workspaceConsentMode;
+    if (isValidConsentMode(workspaceConsentMode)) return workspaceConsentMode;
     const normalizedCountry = country?.trim().toUpperCase() || '';
     return GDPR_COUNTRIES.has(normalizedCountry) ? STRICT_MODE : RELAXED_MODE;
 }
 
-function isConsentMode(value?: string): value is ConsentMode {
+function isValidConsentMode(value?: string): value is ConsentMode {
     return value === STRICT_MODE || value === RELAXED_MODE;
 }
 
@@ -103,10 +103,7 @@ export class ConsentServiceImpl implements ConsentService {
 
         const preference = categoryPreferences[destinationCategory];
 
-        if (preference === ConsentPreference.GRANTED) return true;
         if (preference === ConsentPreference.DENIED) return false;
-
-        // Anything else (UNSPECIFIED or unrecognized value) falls back to mode
-        return consentMode === RELAXED_MODE;
+        return preference === ConsentPreference.GRANTED || consentMode === RELAXED_MODE;
     }
 }

--- a/src/lib/domain/consent.ts
+++ b/src/lib/domain/consent.ts
@@ -29,7 +29,7 @@ export enum ConsentPreference {
 }
 
 export type ConsentCategoryPreferences = {
-    [K in typeof CONSENT_CATEGORIES[number]]?: ConsentPreference;
+    [K in typeof CONSENT_CATEGORIES[number]]: ConsentPreference;
 };
 
 export type Consent = {
@@ -42,7 +42,7 @@ export type ConsentState = {
 }
 
 export interface ConsentService {
-    updateConsent(categoryPreferences: ConsentCategoryPreferences): void;
+    updateConsent(categoryPreferences: Partial<ConsentCategoryPreferences>): void;
     hasConsent(destinationCategory: ConsentCategory | null | undefined): boolean;
     getConsent(): Consent;
 }
@@ -70,7 +70,7 @@ export class ConsentServiceImpl implements ConsentService {
 
     constructor(
         consentMode: ConsentMode,
-        initialConsent?: ConsentCategoryPreferences
+        initialConsent?: Partial<ConsentCategoryPreferences>
     ) {
         this.consentState = {
             consentMode,
@@ -80,7 +80,7 @@ export class ConsentServiceImpl implements ConsentService {
         };
     }
 
-    public updateConsent(categoryPreferences: ConsentCategoryPreferences): void {
+    public updateConsent(categoryPreferences: Partial<ConsentCategoryPreferences>): void {
         for (const [category, preference] of Object.entries(categoryPreferences)) {
             if (CONSENT_CATEGORIES.includes(category as typeof CONSENT_CATEGORIES[number])) {
                 this.consentState.consent.categoryPreferences[category] = preference;

--- a/src/lib/generated/libVersion.ts
+++ b/src/lib/generated/libVersion.ts
@@ -1,2 +1,2 @@
 // This file is generated.
-export const LIB_VERSION = "0.0.210";
+export const LIB_VERSION = "0.0.211";

--- a/src/lib/generated/libVersion.ts
+++ b/src/lib/generated/libVersion.ts
@@ -1,2 +1,2 @@
 // This file is generated.
-export const LIB_VERSION = "0.0.214";
+export const LIB_VERSION = "0.0.211";

--- a/src/lib/generated/libVersion.ts
+++ b/src/lib/generated/libVersion.ts
@@ -1,2 +1,2 @@
 // This file is generated.
-export const LIB_VERSION = "0.0.211";
+export const LIB_VERSION = "0.0.212";

--- a/src/lib/generated/libVersion.ts
+++ b/src/lib/generated/libVersion.ts
@@ -1,2 +1,2 @@
 // This file is generated.
-export const LIB_VERSION = "0.0.212";
+export const LIB_VERSION = "0.0.213";

--- a/src/lib/generated/libVersion.ts
+++ b/src/lib/generated/libVersion.ts
@@ -1,2 +1,2 @@
 // This file is generated.
-export const LIB_VERSION = "0.0.213";
+export const LIB_VERSION = "0.0.214";

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -60,7 +60,7 @@ async function fetchRemoteWriteKeySettings(
       const response = await fetch(settingsUrl);
       if (200 <= response.status && response.status <= 299) {
         const settings = await response.json();
-        settings.countryCode = response.headers.get(countryHeader);
+        settings.country_code = response.headers.get(countryHeader);
         return settings;
       } else if (500 <= response.status && response.status <= 599) {
         if (i < maxRetries - 1) {

--- a/src/lib/transport/plugins/plugin.ts
+++ b/src/lib/transport/plugins/plugin.ts
@@ -46,7 +46,7 @@ type SdkOptions = {
   autoCapturePhoneRegex?: string;
   phoneCountryCode?: string;
   httpCookieServiceOptions?: HttpCookieOptions;
-  initialConsent?: ConsentCategoryPreferences;
+  initialConsent?: Partial<ConsentCategoryPreferences>;
 };
 
 export interface SdkSettings {

--- a/src/lib/transport/plugins/plugin.ts
+++ b/src/lib/transport/plugins/plugin.ts
@@ -6,7 +6,7 @@ import { FieldsMapperFactory } from "./lib/fieldMapping";
 import { HttpCookieOptions } from "../../lib/httpCookieService";
 import { User } from "../../domain/user";
 import { SentryWrapper } from "../../lib/sentry";
-import {ConsentCategoryPreferences} from "../../domain/consent";
+import {ConsentCategoryPreferences, ConsentCategory, ConsentMode} from "../../domain/consent";
 
 export interface Plugin {
   name: string;
@@ -64,7 +64,8 @@ export interface WriteKeySettings {
 export interface Sync {
   id: string;
   destination_app: string;
-  destination_consent_category?: string;
+  destination_consent_category?: ConsentCategory;
+  workspace_consent_mode?: ConsentMode;
   settings: SyncSetting[];
   field_mappings: FieldMapping[];
   event_mappings: EventMapping[];

--- a/src/lib/transport/plugins/plugin.ts
+++ b/src/lib/transport/plugins/plugin.ts
@@ -58,14 +58,14 @@ export interface SdkSettings {
 
 export interface WriteKeySettings {
   syncs: Sync[];
-  countryCode?: string;
+  workspace_consent_mode?: ConsentMode;
+  country_code?: string;
 }
 
 export interface Sync {
   id: string;
   destination_app: string;
   destination_consent_category?: ConsentCategory;
-  workspace_consent_mode?: ConsentMode;
   settings: SyncSetting[];
   field_mappings: FieldMapping[];
   event_mappings: EventMapping[];

--- a/src/lib/transport/plugins/plugin.ts
+++ b/src/lib/transport/plugins/plugin.ts
@@ -58,7 +58,7 @@ export interface SdkSettings {
 
 export interface WriteKeySettings {
   syncs: Sync[];
-  workspace_consent_mode?: ConsentMode;
+  consent_mode?: ConsentMode;
   country_code?: string;
 }
 

--- a/src/lib/transport/plugins/plugin.ts
+++ b/src/lib/transport/plugins/plugin.ts
@@ -46,7 +46,7 @@ type SdkOptions = {
   autoCapturePhoneRegex?: string;
   phoneCountryCode?: string;
   httpCookieServiceOptions?: HttpCookieOptions;
-  initialConsent?: Partial<ConsentCategoryPreferences>;
+  initialConsent?: ConsentCategoryPreferences;
 };
 
 export interface SdkSettings {

--- a/src/test/mocks/consentService.ts
+++ b/src/test/mocks/consentService.ts
@@ -21,7 +21,7 @@ export class ConsentServiceMock implements ConsentService {
         }
     }
 
-    hasConsent(destinationCategory: ConsentCategory): boolean {
+    hasConsent(destinationCategory: ConsentCategory | null | undefined): boolean {
         if (this.funcs?.hasConsent) {
             return this.funcs.hasConsent(destinationCategory);
         }

--- a/src/test/mocks/consentService.ts
+++ b/src/test/mocks/consentService.ts
@@ -15,13 +15,13 @@ export class ConsentServiceMock implements ConsentService {
         this.funcs = funcs || {};
     }
 
-    updateConsent(categoryPreferences: Partial<ConsentCategoryPreferences>): void {
+    updateConsent(categoryPreferences: ConsentCategoryPreferences): void {
         if (this.funcs?.updateConsent) {
             this.funcs.updateConsent(categoryPreferences);
         }
     }
 
-    hasConsent(destinationCategory: ConsentCategory | null | undefined): boolean {
+    hasConsent(destinationCategory: ConsentCategory): boolean {
         if (this.funcs?.hasConsent) {
             return this.funcs.hasConsent(destinationCategory);
         }

--- a/src/test/mocks/consentService.ts
+++ b/src/test/mocks/consentService.ts
@@ -15,7 +15,7 @@ export class ConsentServiceMock implements ConsentService {
         this.funcs = funcs || {};
     }
 
-    updateConsent(categoryPreferences: ConsentCategoryPreferences): void {
+    updateConsent(categoryPreferences: Partial<ConsentCategoryPreferences>): void {
         if (this.funcs?.updateConsent) {
             this.funcs.updateConsent(categoryPreferences);
         }

--- a/src/test/mocks/consentService.ts
+++ b/src/test/mocks/consentService.ts
@@ -1,4 +1,4 @@
-import {Consent, ConsentCategoryPreferences, ConsentPreference, ConsentService} from "../../lib/domain/consent";
+import {Consent, ConsentCategory, ConsentCategoryPreferences, ConsentPreference, ConsentService} from "../../lib/domain/consent";
 
 export class ConsentServiceMock implements ConsentService {
     public funcs: ConsentServiceMockFuncs;
@@ -21,7 +21,7 @@ export class ConsentServiceMock implements ConsentService {
         }
     }
 
-    hasConsent(destinationCategory: string): boolean {
+    hasConsent(destinationCategory: ConsentCategory): boolean {
         if (this.funcs?.hasConsent) {
             return this.funcs.hasConsent(destinationCategory);
         }


### PR DESCRIPTION
# Description
-  Add `workspace_consent_mode` in top level write key settings
- Handle ws consent mode setting to determine the consent mode in Consent init
- Refactor `destination_consent_category` type to be `ConsentCategory` instead of plain string
- Update `ConsentCategory` values to be upper-case for consistency with backend and dashboard

# Linear Issue
[PRO-790](https://linear.app/journify-infra/issue/PRO-790/add-workspace-setting-to-update-consent-mode)


---
***When reviewing this PR, please adhere to [conventional comments](https://conventionalcomments.org).***