### PR TITLE
Remove consent warning

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -213,7 +213,6 @@ function recordCallBeforeLoad(call) {
 function updateConsent(categoryPreferences: ConsentCategoryPreferences): void {
   try {
     if (!sdk) {
-      console.warn('[Journify] SDK not loaded yet. Consent will be updated once SDK loads.');
       recordCallBeforeLoad(() => updateConsent(categoryPreferences));
       return;
     }


### PR DESCRIPTION
# Description
This warning will be always there on gtm for the facebook pixel wrapper which might cause some customer unecessary panic during integration.
